### PR TITLE
solved paratext sync issue and added Migration documentation

### DIFF
--- a/src/ClearDashboard.Wpf.Application/Models/ProjectSerialization/EnhancedViewLayout.cs
+++ b/src/ClearDashboard.Wpf.Application/Models/ProjectSerialization/EnhancedViewLayout.cs
@@ -10,7 +10,7 @@ public class EnhancedViewLayout
         EnhancedViewItems = new BindableCollection<EnhancedViewItemMetadatum>();
     }
     public string? Title { get; set; } = string.Empty;
-    public bool ParatextSync { get; set; }
+    public bool ParatextSync { get; set; } = true;
     public string? BBBCCCVVV { get; set; } = "001001001";
     public BindableCollection<EnhancedViewItemMetadatum> EnhancedViewItems { get; set; } 
     public int VerseOffset { get; set; }

--- a/src/ClearDashboard.Wpf.Application/UserControls/LabelsDisplay.xaml
+++ b/src/ClearDashboard.Wpf.Application/UserControls/LabelsDisplay.xaml
@@ -18,17 +18,17 @@
                 BorderThickness="{Binding RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Path=BorderThickness}"
                 CornerRadius="{Binding RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Path=LabelCornerRadius}">
                 <StackPanel Orientation="Horizontal">
-                    <TextBlock Text="{Binding Path=Text}" Width="85"/>
+                    <TextBlock Width="85" Text="{Binding Path=Text}" />
                     <Button
                         Name="RemoveLabelButton"
                         Height="12"
                         Margin="8,0,0,0"
                         Padding="0,0,0,0"
+                        HorizontalContentAlignment="Right"
                         Background="Transparent"
                         BorderThickness="0"
                         Click="OnRemoveLabel"
                         FontSize="11"
-                        HorizontalContentAlignment="Right"
                         FontWeight="Bold"
                         ToolTip="Remove this label">
                         X

--- a/src/ClearDashboard.Wpf.Application/UserControls/NoteDisplay.xaml
+++ b/src/ClearDashboard.Wpf.Application/UserControls/NoteDisplay.xaml
@@ -194,8 +194,8 @@
                         LabelPadding="{Binding RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Path=LabelPadding}"
                         LabelRemoved="OnLabelRemoved"
                         Labels="{Binding RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Path=Note.Labels}"
-                        Note="{Binding RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Path=Note}" 
-                        Orientation="Vertical"/>
+                        Note="{Binding RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Path=Note}"
+                        Orientation="Vertical" />
                     <userControls:LabelSelector
                         HorizontalAlignment="Center"
                         VerticalAlignment="Center"

--- a/src/ClearDashboard.Wpf.Application/ViewModels/EnhancedView/EnhancedViewModel.cs
+++ b/src/ClearDashboard.Wpf.Application/ViewModels/EnhancedView/EnhancedViewModel.cs
@@ -392,7 +392,6 @@ namespace ClearDashboard.Wpf.Application.ViewModels.EnhancedView
             VerseOffsetRange = enhancedViewLayout.VerseOffset;
             BcvDictionary = ProjectManager!.CurrentParatextProject.BcvDictionary;
             ParatextSync = enhancedViewLayout.ParatextSync;
-            CurrentBcv.SetVerseFromId(enhancedViewLayout.BBBCCCVVV);
 
             EventAggregator.SubscribeOnPublishedThread(this);
 

--- a/src/ClearDashboard.sln
+++ b/src/ClearDashboard.sln
@@ -24,6 +24,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		..\Caliburn-Micro-Cheat-Sheet.md = ..\Caliburn-Micro-Cheat-Sheet.md
 		..\CQRS-Cheat-Sheet.md = ..\CQRS-Cheat-Sheet.md
 		..\Localization-How-To.md = ..\Localization-How-To.md
+		Migration-How-To.md = Migration-How-To.md
 		..\NuGet-Configuration.md = ..\NuGet-Configuration.md
 		..\Paratext-Installation.md = ..\Paratext-Installation.md
 		..\Paratext_SendReceive_Documentation.md = ..\Paratext_SendReceive_Documentation.md

--- a/src/Migration-How-To.md
+++ b/src/Migration-How-To.md
@@ -1,0 +1,4 @@
+To create a migration do the following:
+1. From the `ClearDashboard.DAL.Data` project, right click and choose:  `Open in Terminal`
+2. In the terminal type `dotnet-ef migrations add <Your Migration Name>`
+This will create a new migration in the Migrations folder and will update the ProjectDbContextModelSnapshot file.


### PR DESCRIPTION
I set the default value of ParatextSync to true and removed a line of code where the BCV control is set to Gen 1:1 initially no matter what.  I also added a brief markdown file with some instructions on how to do a migration.