### PR TITLE
Fixed missing word clock icons and cut off text in text collections

### DIFF
--- a/src/ClearDashboard.Wpf.Application/UserControls/ClockUserControl.xaml
+++ b/src/ClearDashboard.Wpf.Application/UserControls/ClockUserControl.xaml
@@ -12,6 +12,22 @@
     d:DesignWidth="800"
     helpers:Translation.ResourceManager="{x:Static resx:Resources.ResourceManager}"
     mc:Ignorable="d">
+    <UserControl.Resources>
+        <Style x:Key="TransparentStyleLite" TargetType="{x:Type Button}">
+            <Setter Property="HorizontalContentAlignment" Value="Center" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+            <Setter Property="Height" Value="50" />
+            <Setter Property="MinWidth" Value="100" />
+
+            <Style.Triggers>
+                <Trigger Property="IsEnabled" Value="False">
+                    <Setter Property="Opacity" Value="1" />
+                    <Setter Property="Foreground" Value="Gray" />
+                    <Setter Property="Background" Value="LightGray" />
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+    </UserControl.Resources>
     <Grid
         Height="36"
         Margin="-1"
@@ -65,7 +81,7 @@
                                 VerticalContentAlignment="Center"
                                 Click="AddButton_OnClick"
                                 Content="+"
-                                Style="{StaticResource TransparentStyle}"
+                                Style="{StaticResource TransparentStyleLite}"
                                 Tag="{Binding MenuItems, Mode=TwoWay}"
                                 ToolTip="Add"
                                 Visibility="{Binding AddButtonVisibility}" />
@@ -78,7 +94,7 @@
                                 VerticalAlignment="Center"
                                 VerticalContentAlignment="Center"
                                 Click="DeleteButton_OnClick"
-                                Style="{StaticResource TransparentStyle}"
+                                Style="{StaticResource TransparentStyleLite}"
                                 ToolTip="Delete"
                                 Visibility="{Binding DeleteButtonVisibility, Mode=TwoWay}">
                                 <materialDesign:PackIcon Kind="TrashCanOutline" />

--- a/src/ClearDashboard.Wpf.Application/Views/ParatextViews/TextCollectionsView.xaml
+++ b/src/ClearDashboard.Wpf.Application/Views/ParatextViews/TextCollectionsView.xaml
@@ -4,6 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:cef="clr-namespace:CefSharp.Wpf;assembly=CefSharp.Wpf"
     xmlns:cm="http://caliburnmicro.com"
+    xmlns:converters="clr-namespace:ClearDashboard.Wpf.Application.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:helpers="clr-namespace:ClearDashboard.Wpf.Application.Helpers"
     xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
@@ -88,17 +89,17 @@
                             </Style>
                         </GridView.ColumnHeaderContainerStyle>
 
-                        <GridViewColumn Width="{Binding ActualWidth, ElementName=TextCollectionListView}">
+                        <GridViewColumn x:Name="TextCollectionItemGridViewColumn" Width="{Binding ActualWidth, ElementName=TextCollectionListView, Converter={converters:WidthSubtraction}, ConverterParameter='20'}">
                             <GridViewColumn.CellTemplate>
                                 <DataTemplate>
-                                    <StackPanel Margin="0,0,30,0" Orientation="Vertical">
+                                    <StackPanel Orientation="Vertical">
                                         <helpers:BindableTextBlock
                                             Width="Auto"
                                             InlineList="{Binding Path=Inlines, UpdateSourceTrigger=PropertyChanged}"
                                             TextWrapping="Wrap" />
                                         <cef:ChromiumWebBrowser
                                             x:Name="TextCollectionWebBrowser"
-                                            Width="{Binding ActualWidth, ElementName=TextCollectionListView}"
+                                            Width="{Binding ActualWidth, ElementName=TextCollectionItemGridViewColumn, Converter={converters:WidthSubtraction}, ConverterParameter='15'}"
                                             Height="200"
                                             paratextViews:ChromiumWebBrowserHelper.Body="{Binding MyHtml}" />
                                     </StackPanel>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/60048070/210400473-14b262f5-9133-4b00-99f1-354cb5420160.png)

![image](https://user-images.githubusercontent.com/60048070/210400757-4423644c-cb0a-4a0d-a0ef-edbb0925f84d.png)

