### PR TITLE
Stopping running instances of Paratext for DEBUG builds of Dashboard.

### DIFF
--- a/src/ClearDashboard.DAL/Paratext/ParatextProxy.cs
+++ b/src/ClearDashboard.DAL/Paratext/ParatextProxy.cs
@@ -73,6 +73,30 @@ namespace ClearDashboard.DataAccessLayer.Paratext
             return Process.GetProcessesByName("Paratext").Length > 0;
         }
 
+        public void StopParatext()
+        {
+            try
+            {
+                var processes = Process.GetProcessesByName("Paratext");
+                if (processes.Length > 0)
+                {
+                    _logger.LogInformation($"Paratext is running with {processes.Length} instances, stopping all instances.");
+                    foreach (var process in processes)
+                    { 
+                        process.Kill(true);
+                        _logger.LogInformation($"Paratext - instance '{process.Id}' stopped.");
+                    }
+                    return;
+                }
+
+                _logger.LogInformation("Paratext is not running.");
+            }
+            catch (Exception ex)
+            {
+                _logger .LogError(ex, "An unexpected error occurred while stopping Paratext.");
+            }
+        }
+
         public  async Task<Process> StartParatextAsync(int secondsToWait = 10)
         {
             var paratext = Process.GetProcessesByName("Paratext");
@@ -97,21 +121,6 @@ namespace ClearDashboard.DataAccessLayer.Paratext
 
 
         }
-
-        //protected async Task StopParatextAsync()
-        //{
-        //    if (StopParatextOnTestConclusion)
-        //    {
-        //        Output.WriteLine("Stopping Paratext.");
-        //        Process.Kill(true);
-
-        //        Process = null;
-
-        //        var seconds = 2;
-        //        Output.WriteLine($"Waiting for {seconds} seconds for Paratext to stop.");
-        //        await Task.Delay(TimeSpan.FromSeconds(seconds));
-        //    }
-        //}
 
         private  async Task<Process> InternalStartParatextAsync()
         {

--- a/src/ClearDashboard.Wpf.Application/Bootstrapper.cs
+++ b/src/ClearDashboard.Wpf.Application/Bootstrapper.cs
@@ -21,6 +21,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
+using ClearDashboard.DataAccessLayer.Paratext;
 using DashboardApplication = System.Windows.Application;
 
 namespace ClearDashboard.Wpf.Application
@@ -206,6 +207,13 @@ namespace ClearDashboard.Wpf.Application
         protected override void OnExit(object sender, EventArgs e)
         {
             Logger?.LogInformation("ClearDashboard application is exiting.");
+
+#if DEBUG
+            if (Container!.Resolve<ParatextProxy>() is { } paratextProxy)
+            {
+                paratextProxy.StopParatext();
+            }
+#endif
 
             Logger?.LogInformation("Disposing ILifetimeScope" );
             var lifetimeScope = Container!.Resolve<ILifetimeScope>();

--- a/src/ClearDashboard.Wpf.Application/ClearDashboard.Wpf.Application.csproj
+++ b/src/ClearDashboard.Wpf.Application/ClearDashboard.Wpf.Application.csproj
@@ -487,6 +487,22 @@
     <SelfContained Condition="'$(SelfContained)' == ''">false</SelfContained>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DefineConstants>$(DefineConstants)TRACE</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DefineConstants>$(DefineConstants)TRACE</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <DefineConstants>$(DefineConstants)TRACE</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <DefineConstants>$(DefineConstants)TRACE</DefineConstants>
+  </PropertyGroup>
+
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
     <Exec Command="powershell -Command &quot;((Get-Date).ToUniversalTime()).ToString(\&quot;s\&quot;) | Out-File '$(ProjectDir)Resources\BuildDate.txt'&quot;" />
   </Target>


### PR DESCRIPTION
Stopping running instances of Paratext for DEBUG builds of Dashboard to address the fact that having dangling Paratext instances prevents the Paratext plug-in binaries from being copied to the Paratext plug-in directory, which can cause false flag errors when running the Dashboard application by developers (i.e., this will not impact RELEASE builds in any manner).