### PR TITLE
Updated Installer Version Number for Internal Release

### DIFF
--- a/installer/DashboardInstaller.iss
+++ b/installer/DashboardInstaller.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Clear Dashboard"
-#define MyAppVersion "0.4.7.1"
+#define MyAppVersion "0.5.0.0"
 #define MyAppPublisher "Clear Bible, Inc."
 #define MyAppURL "https://www.clear.bible/"
 #define MyAppExeName "ClearDashboard.Wpf.Application.exe"


### PR DESCRIPTION
An internal release for testing purposes was requested by the rollout team.  All that needed to be altered for this release was the installer's version number. 