### PR TITLE
Moving TextCollections' cross-references and footnotes to tooltips 

### DIFF
--- a/src/ClearDashboard.Wpf.Application/Resources/usx.xslt
+++ b/src/ClearDashboard.Wpf.Application/Resources/usx.xslt
@@ -221,7 +221,7 @@
           .x {
           display: none;
           width: calc(98vw - 35px);
-          background: #fff;
+          background: #ffffd4;
           border-radius: 6px;
           padding: 5px 5px;
           left: 10px;
@@ -260,7 +260,7 @@
           .f {
           display: none;
           width: calc(98vw - 35px);
-          background: #fff;
+          background: #ffffd4;
           border-radius: 6px;
           padding: 5px 5px;
           left: 10px;
@@ -720,7 +720,7 @@
           font-style: normal;}
 
           .vh {
-          background-color:#f5f571;}
+          background-color:#ffffd4;}
 
           .res {
           font-weight: bold;


### PR DESCRIPTION
https://clearbible.atlassian.net/browse/DI-129

I decided to give cross-references the same treatment as requested for footnotes.  Do any colors/styling things need to be changed?  Is there something better to put than xref_ and fnote_?  Should the text be bigger?

How cross-references and footnotes used to look in TextCollections:
![image](https://user-images.githubusercontent.com/60048070/219386584-b42ba74d-7001-4af8-903a-2ab7791c6e48.png)

How they look now:
![image](https://user-images.githubusercontent.com/60048070/219385432-fece3c37-035b-4fd0-856b-6330597f4dce.png)

a footnote from the current verse:
![image](https://user-images.githubusercontent.com/60048070/219385633-f1805d4c-1eff-4ced-93af-f4dbe738ce79.png)

a cross-reference from not the current verse:
![image](https://user-images.githubusercontent.com/60048070/219385749-74ffc409-c690-4887-8391-3a1c53fd8d14.png)
