### PR TITLE
Fix for the Accept button not allowing the same word to propagate as "accepted"

### DIFF
--- a/src/ClearDashboard.Wpf.Application.Abstractions/Dialogs/TranslationSelectionDialog.xaml.cs
+++ b/src/ClearDashboard.Wpf.Application.Abstractions/Dialogs/TranslationSelectionDialog.xaml.cs
@@ -107,17 +107,14 @@ namespace ClearDashboard.Wpf.Application.Dialogs
         {
             try
             {
-                if (!TokenDisplay.TargetTranslationText.Equals(e.Translation.TargetTranslationText))
+                OnUIThread(() => ProgressBarVisibility = Visibility.Visible);
+
+                async Task ApplyTranslation()
                 {
-                    OnUIThread(() => ProgressBarVisibility = Visibility.Visible);
-
-                    async Task ApplyTranslation()
-                    {
-                        await InterlinearDisplay.PutTranslationAsync(e.Translation, e.TranslationActionType);
-                    }
-
-                    await System.Windows.Application.Current.Dispatcher.InvokeAsync(ApplyTranslation);
+                    await InterlinearDisplay.PutTranslationAsync(e.Translation, e.TranslationActionType);
                 }
+
+                await System.Windows.Application.Current.Dispatcher.InvokeAsync(ApplyTranslation);
 
                 System.Windows.Application.Current.Dispatcher.Invoke(() => DialogResult = true);
             }


### PR DESCRIPTION
Removed the code that checked if the word being accepted is the same word as before.  This prevented an end user from accepting that the glosssed word was "good".

