### PR TITLE
Improved scrolling and tab loading time

### DIFF
--- a/src/ClearDashboard.Wpf.Application/Views/PopUps/ShowUpdateNotesView.xaml
+++ b/src/ClearDashboard.Wpf.Application/Views/PopUps/ShowUpdateNotesView.xaml
@@ -96,7 +96,8 @@
                     VerticalAlignment="Top"
                     HorizontalContentAlignment="Stretch"
                     VerticalContentAlignment="Stretch"
-                    ItemsSource="{Binding Updates}">
+                    ItemsSource="{Binding Updates}"
+                    ScrollViewer.CanContentScroll="False">
                     <ListView.Style>
                         <Style TargetType="{x:Type ListView}">
                             <Setter Property="Visibility" Value="Visible" />
@@ -119,7 +120,8 @@
                                     VerticalAlignment="Top"
                                     HorizontalContentAlignment="Stretch"
                                     VerticalContentAlignment="Stretch"
-                                    ItemsSource="{Binding ReleaseNotes}">
+                                    ItemsSource="{Binding ReleaseNotes}"
+                                    PreviewMouseWheel="NotesList_OnPreviewMouseWheel">
                                     <ListView.Style>
                                         <Style TargetType="{x:Type ListView}">
                                             <Setter Property="Visibility" Value="Visible" />
@@ -208,7 +210,7 @@
                                                 </GridViewColumn.CellTemplate>
                                             </GridViewColumn>
 
-                                            <GridViewColumn Width="{Binding ElementName=NotesList, Path=ActualWidth, Converter={converters:WidthSubtraction}, ConverterParameter='170'}">
+                                            <GridViewColumn Width="551">
                                                 <GridViewColumn.CellTemplate>
                                                     <DataTemplate>
                                                         <TextBlock

--- a/src/ClearDashboard.Wpf.Application/Views/PopUps/ShowUpdateNotesView.xaml.cs
+++ b/src/ClearDashboard.Wpf.Application/Views/PopUps/ShowUpdateNotesView.xaml.cs
@@ -23,5 +23,12 @@ namespace ClearDashboard.Wpf.Application.Views.PopUps
         {
             InitializeComponent();
         }
+
+        private void NotesList_OnPreviewMouseWheel(object sender, MouseWheelEventArgs e)
+        {
+            ScrollViewer scrollViewer = Helpers.Helpers.GetChildOfType<ScrollViewer>(UpdateList);
+            scrollViewer.ScrollToVerticalOffset(scrollViewer.VerticalOffset - e.Delta/3);
+            e.Handled = true;
+        }
     }
 }


### PR DESCRIPTION
The `ReleaseNotes` tab in the `ShowUpdateNotesView.xaml` felt really laggy.

1. added mouse wheel scrolling
2. made scrolling smooth
3. made `width` an int instead of a calculation to reduce xaml rendering time