### PR TITLE
Fixing null AllSelectedTokens on right click of composite

### DIFF
--- a/src/ClearDashboard.Wpf.Application.Abstractions/Services/SelectionManager.cs
+++ b/src/ClearDashboard.Wpf.Application.Abstractions/Services/SelectionManager.cs
@@ -68,7 +68,7 @@ namespace ClearDashboard.Wpf.Application.Services
 
         public void UpdateRightClickSelection(TokenDisplayViewModel token)
         {
-            if (!SelectedTokens.Contains(token))
+            if (!SelectedTokens.Contains(token) || token.CompositeToken !=null)
             {
                 SelectedTokens = new TokenDisplayViewModelCollection(token);
                 SelectionUpdated();

--- a/src/ClearDashboard.Wpf.Application/UserControls/TokenDisplay.xaml.cs
+++ b/src/ClearDashboard.Wpf.Application/UserControls/TokenDisplay.xaml.cs
@@ -844,18 +844,9 @@ namespace ClearDashboard.Wpf.Application.UserControls
 
         private void OnTokenContextMenuOpening(object sender, ContextMenuEventArgs e)
         {
-            if (AllSelectedTokens != null)
-            {
-                JoinTokensMenuItem.Visibility = AllSelectedTokens.CanJoinTokens ? Visibility.Visible : Visibility.Collapsed;
-                JoinTokensLanguagePairMenuItem.Visibility = AllSelectedTokens.CanJoinTokens && !IsCorpusView ? Visibility.Visible : Visibility.Collapsed;
-                UnjoinTokenMenuItem.Visibility = AllSelectedTokens.CanUnjoinToken ? Visibility.Visible : Visibility.Collapsed;
-            }
-            else
-            {
-                JoinTokensMenuItem.Visibility = Visibility.Collapsed;
-                JoinTokensLanguagePairMenuItem.Visibility =  Visibility.Collapsed;
-                UnjoinTokenMenuItem.Visibility =  Visibility.Visible;
-            }
+            JoinTokensMenuItem.Visibility = AllSelectedTokens.CanJoinTokens ? Visibility.Visible : Visibility.Collapsed;
+            JoinTokensLanguagePairMenuItem.Visibility = AllSelectedTokens.CanJoinTokens && !IsCorpusView ? Visibility.Visible : Visibility.Collapsed;
+            UnjoinTokenMenuItem.Visibility = AllSelectedTokens.CanUnjoinToken ? Visibility.Visible : Visibility.Collapsed;
             
             var tokenDisplay = (TokenDisplayViewModel) DataContext;
             DeleteAlignmentMenuItem.Visibility = tokenDisplay.IsAligned ? Visibility.Visible : Visibility.Collapsed;


### PR DESCRIPTION
https://clearbible.atlassian.net/browse/DI-154

I encountered an error when right clicking on a composite token right after joining. 
![image](https://user-images.githubusercontent.com/60048070/222562620-f9a8ce3b-dec7-4e4f-8f37-8d8ccc7fabe1.png)

It turns out the property `AllSelectedTokens` in the `TokenDisplay.xaml.cs` was null.  
![image](https://user-images.githubusercontent.com/60048070/222562665-103a29bd-758f-4b12-89e2-670cfef748af.png)

In order for the correct menu items to show I chose to allow the  `SelectionUpdatedMessage` to run when a composite token is right clicked no matter what.  Previously it wasn't running since those tokens were already selected.  

There may be a better way of fixing this error and get at the root of the problem, if so let me know and I'll be happy to change it.