### PR TITLE
Notes indicator does not properly remove when deleting multi word notes

### DIFF
--- a/src/ClearDashboard.Wpf.Application/ViewModels/EnhancedView/EnhancedViewModel.cs
+++ b/src/ClearDashboard.Wpf.Application/ViewModels/EnhancedView/EnhancedViewModel.cs
@@ -24,7 +24,8 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
-
+using ClearDashboard.Wpf.Application.Collections;
+using SIL.Linq;
 using Uri = System.Uri;
 
 namespace ClearDashboard.Wpf.Application.ViewModels.EnhancedView
@@ -855,9 +856,12 @@ namespace ClearDashboard.Wpf.Application.ViewModels.EnhancedView
         {
             if (e.Note.NoteId != null)
             {
+                EntityIdCollection associationIds= new();
+                e.Note.Associations.ForEach(a => associationIds.Add(a.AssociatedEntityId));
+
                 await Execute.OnUIThreadAsync(async () =>
                 {
-                    await NoteManager.DeleteNoteAsync(e.Note, e.EntityIds);
+                    await NoteManager.DeleteNoteAsync(e.Note, associationIds);
                     NotifyOfPropertyChange(() => Items);
                 });
             }


### PR DESCRIPTION
https://clearbible.atlassian.net/browse/DI-134

Previously the entity ids being passed in were those of the selected tokens, sometimes leaving a token with a note marker after the note was deleted.  Now the tokens are visually updated not based on what is highlighted but what is associated with the note.  

Could this create any unintended issues, for example with the behavior of composites?  I did a bit of testing and didn't notice any issues.  