### PR TITLE
Refactored menuing to use a method instead of a property to invoke menu commands

### DIFF
--- a/src/ClearDashboard.Wpf.Application/ViewModels/Main/MainViewModel.cs
+++ b/src/ClearDashboard.Wpf.Application/ViewModels/Main/MainViewModel.cs
@@ -53,7 +53,7 @@ using Point = System.Drawing.Point;
 namespace ClearDashboard.Wpf.Application.ViewModels.Main
 {
 
-    public class MainViewModel : Conductor<IScreen>.Collection.AllActive, 
+    public class MainViewModel : Conductor<IScreen>.Collection.AllActive,
                 IEnhancedViewManager,
                 IHandle<ProgressBarVisibilityMessage>,
                 IHandle<ProgressBarMessage>,
@@ -61,7 +61,7 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Main
                 IHandle<ActiveDocumentMessage>,
                 IHandle<CloseDockingPane>,
                 IHandle<ApplicationWindowSettings>,
-                IHandle<FilterPinsMessage>, 
+                IHandle<FilterPinsMessage>,
                 IHandle<BackgroundTaskChangedMessage>
     {
         #region Member Variables
@@ -157,89 +157,7 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Main
         public string WindowIdToLoad
         {
             get => _windowIdToLoad;
-            set
-            {
-                if (value.StartsWith("ProjectLayout:") || value.StartsWith("StandardLayout"))
-                {
-                    LoadLayoutById(value);
-                }
-                else if (value == "SeparatorID")
-                {
-                    // no op
-                }
-                else if (value == "SaveID")
-                {
-                    GridIsVisible = Visibility.Visible;
-                    DeleteGridIsVisible = Visibility.Collapsed;
-                }
-                else if (value == "DeleteID")
-                {
-                    DeleteGridIsVisible = Visibility.Visible;
-                    GridIsVisible = Visibility.Collapsed;
-                }
-                else if (value == "NewEnhancedCorpusID")
-                {
-                   AddNewEnhancedView().Wait();
-                }
-                else if (value == "GettingStartedGuideID")
-                {
-                    LaunchGettingStartedGuide();
-                }
-                else if (value == "ShowLogID")
-                {
-                    ShowLogs();
-                }
-                else if (value == "GatherLogsID")
-                {
-                    GatherLogs();
-                }
-                else if (value == "SettingsID")
-                {
-                    this.WindowManager.ShowWindowAsync(new DashboardSettingsViewModel(), null, null);
-                }
-                else if (value == "AboutID")
-                {
-                    ShowAboutWindow();
-                }
-                else
-                {
-                    switch (value)
-                    {
-                        case "LayoutID":
-                            Console.WriteLine();
-                            break;
-                        case "BiblicalTermsID":
-                            _windowIdToLoad = "BIBLICALTERMS";
-                            break;
-                        case "EnhancedCorpusID":
-                            _windowIdToLoad = "ENHANCEDVIEW";
-                            break;
-                        case "PINSID":
-                            _windowIdToLoad = "PINS";
-                            break;
-                        //case "WordMeaningsID":
-                        //    _windowIdToLoad = "WORDMEANINGS";
-                        //    break;
-                        case "MarbleID":
-                            _windowIdToLoad = "MARBLE";
-                            break;
-                        case "TextCollectionID":
-                            _windowIdToLoad = "TEXTCOLLECTION";
-                            break;
-                        case "NotesId":
-                            _windowIdToLoad = "NOTES";
-                            break;
-
-                        default:
-                            _windowIdToLoad = value;
-                            break;
-                    }
-
-                    UnhideWindow(WindowIdToLoad);
-                }
-
-                NotifyOfPropertyChange(() => WindowIdToLoad);
-            }
+            set => Set(ref _windowIdToLoad, value);
         }
 
         private BindableCollection<MenuItemViewModel> _menuItems = new();
@@ -347,7 +265,7 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Main
         // ReSharper disable once UnusedMember.Global
         public MainViewModel()
         {
-           
+
             // no-op for design time support
         }
 
@@ -448,7 +366,7 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Main
             _dockingManager.ActiveContentChanged -= OnActiveContentChanged;
             _dockingManager.DocumentClosed -= OnEnhancedViewClosed;
 
-           
+
 
             if (_lastLayout == "")
             {
@@ -469,7 +387,7 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Main
 
             // Clear the items in the event the user is switching projects.
             Items.Clear();
-            
+
             OpenProjectManager.RemoveProjectToOpenProjectList(ProjectManager);
 
             return base.OnDeactivateAsync(close, cancellationToken);
@@ -516,7 +434,7 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Main
                                     var vm = (EnhancedViewModel)a.Content;
                                     if (vm.PaneId == id)
                                     {
-                                    return true;
+                                        return true;
                                     }
                                 }
                             }
@@ -640,7 +558,7 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Main
 
         private async Task LoadEnhancedViewTabs(CancellationToken cancellationToken)
         {
-            _=Task.Run(async () =>
+            _ = Task.Run(async () =>
             {
                 var sw = Stopwatch.StartNew();
                 var enhancedViews = LoadEnhancedViewTabLayout();
@@ -656,6 +574,8 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Main
                 sw.Stop();
                 Logger.LogInformation($"LoadEnhancedViewTabs - Total Load Time {enhancedViews.Count} documents in {sw.ElapsedMilliseconds} ms");
             }, cancellationToken);
+
+            await Task.CompletedTask;
         }
 
         private IEnumerable<EnhancedViewModel> EnhancedViewModels => Items.Where(item => item is EnhancedViewModel).Cast<EnhancedViewModel>();
@@ -664,9 +584,8 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Main
         private async Task LoadEnhancedViewData(List<EnhancedViewLayout> enhancedViews)
         {
             var orderedViews = enhancedViews.AsParallel().AsOrdered();
-            
+
             await Parallel.ForEachAsync(orderedViews, new ParallelOptions(), async (enhancedView, cancellationToken) =>
-            //foreach (var enhancedView in enhancedViews)
             {
 
                 var enhancedViewModel = EnhancedViewModels.FirstOrDefault(item => item.Title == enhancedView.Title);
@@ -680,16 +599,13 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Main
                 enhancedViewModel.EnableBcvControl = false;
                 try
                 {
-                    //await enhancedViewModel.LoadData(cancellationToken);
                     await enhancedViewModel.LoadData(CancellationToken.None);
                 }
                 finally
                 {
                     enhancedViewModel.EnableBcvControl = true;
                 }
-
-            //} 
-        });
+            });
         }
 
 
@@ -735,7 +651,7 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Main
 
         private List<EnhancedViewLayout> LoadEnhancedViewTabLayout()
         {
-            if (ProjectManager.CurrentProject?.WindowTabLayout is null ||ProjectManager.CurrentProject?.WindowTabLayout == "[null]")
+            if (ProjectManager.CurrentProject?.WindowTabLayout is null || ProjectManager.CurrentProject?.WindowTabLayout == "[null]")
             {
                 var newLayouts = new List<EnhancedViewLayout>
                 {
@@ -843,45 +759,45 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Main
             switch (direction)
             {
                 case Direction.Forwards:
-                {
-                    if (currentDocumentIndex == documents.Count - 1)
                     {
-                        documents.First().IsSelected = true;
-                        return;
+                        if (currentDocumentIndex == documents.Count - 1)
+                        {
+                            documents.First().IsSelected = true;
+                            return;
+                        }
+
+                        var nextDocument = documents
+                            .Skip(currentDocumentIndex + 1)
+                            .Take(1)
+                            .FirstOrDefault();
+
+                        if (nextDocument != null)
+                        {
+                            nextDocument.IsSelected = true;
+                        }
+                        break;
                     }
-
-                    var nextDocument = documents
-                        .Skip(currentDocumentIndex + 1)
-                        .Take(1)
-                        .FirstOrDefault();
-
-                    if (nextDocument != null)
-                    {
-                        nextDocument.IsSelected = true;
-                    } 
-                    break;
-                }
 
                 case Direction.Backwards:
-                {
-                    // If first document reached, show last again
-                    if (currentDocumentIndex == 0)
                     {
-                        documents.Last().IsSelected = true;
-                        return;
-                    }
+                        // If first document reached, show last again
+                        if (currentDocumentIndex == 0)
+                        {
+                            documents.Last().IsSelected = true;
+                            return;
+                        }
 
-                    var nextDocument = documents
-                        .Skip(currentDocumentIndex - 1)
-                        .Take(1)
-                        .FirstOrDefault();
+                        var nextDocument = documents
+                            .Skip(currentDocumentIndex - 1)
+                            .Take(1)
+                            .FirstOrDefault();
 
-                    if (nextDocument != null)
-                    {
-                        nextDocument.IsSelected = true;
+                        if (nextDocument != null)
+                        {
+                            nextDocument.IsSelected = true;
+                        }
+                        break;
                     }
-                    break;
-                }
             }
         }
 
@@ -962,7 +878,7 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Main
             {
                 try
                 {
-                    Rectangle bounds = new Rectangle(0,0,0,0);
+                    Rectangle bounds = new Rectangle(0, 0, 0, 0);
 
                     System.Windows.Point screenPoint = new System.Windows.Point((int)_windowSettings.Left, (int)_windowSettings.Top);
 
@@ -1070,7 +986,7 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Main
             viewModel.CurrentBcv.SetVerseFromId(ProjectManager.CurrentVerse);
             viewModel.VerseChange = ProjectManager.CurrentVerse;
             viewModel.EnhancedViewLayout = new EnhancedViewLayout();
-           
+
 
 
             // add vm to conductor
@@ -1158,14 +1074,14 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Main
                 // Save Current Layout
                 new MenuItemViewModel
                 {
-                    Header = "🖫 " + _localizationService!.Get("MainView_LayoutsSave"), Id = "SaveID",
+                    Header = "🖫 " + _localizationService!.Get("MainView_LayoutsSave"), Id = MenuIds.Save,
                     ViewModel = this
                 },
                 
                 // Delete Saved Layout
                 new MenuItemViewModel
                 {
-                    Header = "🗑 " +_localizationService!.Get("MainView_LayoutsDelete"), Id = "DeleteID",
+                    Header = "🗑 " +_localizationService!.Get("MainView_LayoutsDelete"), Id = MenuIds.Delete,
                     ViewModel = this,
                 },
 
@@ -1173,7 +1089,7 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Main
                 new MenuItemViewModel
                 {
                     Header = "---- " + _localizationService!.Get("MainView_LayoutsStandardLayouts") + " ----",
-                    Id = "SeparatorID", ViewModel = this,
+                    Id = MenuIds.Separator, ViewModel = this,
                 }
             };
 
@@ -1186,7 +1102,7 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Main
                     layouts.Add(new MenuItemViewModel
                     {
                         Header = "---- " + _localizationService!.Get("MainView_LayoutsProjectLayouts") + " ----",
-                        Id = "SeparatorID",
+                        Id = MenuIds.Separator,
                         ViewModel = this,
                     });
                     bFound = true;
@@ -1209,52 +1125,52 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Main
                 // File
                 new()
                 {
-                    Header =_localizationService!.Get("MainView_File"), Id = "FileID", ViewModel = this, IsEnabled = tasksRunning,
+                    Header =_localizationService!.Get("MainView_File"), Id = MenuIds.File, ViewModel = this, IsEnabled = tasksRunning,
                     MenuItems = new BindableCollection<MenuItemViewModel>
                     {
                         // New
-                        new() { Header =_localizationService!.Get("MainView_FileNew"), Id = "NewID", ViewModel = this, IsEnabled = true },
-                        new() { Header = _localizationService!.Get("MainView_FileOpen"), Id = "OpenID", ViewModel = this, IsEnabled = true }
+                        new() { Header =_localizationService!.Get("MainView_FileNew"), Id = MenuIds.FileNew, ViewModel = this, IsEnabled = true },
+                        new() { Header = _localizationService!.Get("MainView_FileOpen"), Id = MenuIds.FileOpen, ViewModel = this, IsEnabled = true }
                     }
                 },
                 new()
                 {
                     // Layouts
-                    Header = _localizationService!.Get("MainView_Layouts"), Id = "LayoutID", ViewModel = this,
+                    Header = _localizationService!.Get("MainView_Layouts"), Id = MenuIds.Layout, ViewModel = this,
                     MenuItems = layouts,
                 },
                 new()
                 {
                     // Windows
-                    Header = _localizationService!.Get("MainView_Windows"), Id = "WindowID", ViewModel = this,
+                    Header = _localizationService!.Get("MainView_Windows"), Id = MenuIds.Window, ViewModel = this,
                     MenuItems = new BindableCollection<MenuItemViewModel>
                     {
                         // Enhanced Corpus
-                        new() { Header = "⳼ " + _localizationService!.Get("MainView_WindowsNewEnhancedView"), Id = "NewEnhancedCorpusID", ViewModel = this, },
+                        new() { Header = "⳼ " + _localizationService!.Get("MainView_WindowsNewEnhancedView"), Id = MenuIds.NewEnhancedCorpus, ViewModel = this, },
 
                         // separator
                         new() { Header = "---------------------------------", Id = "SeparatorID", ViewModel = this, },
 
                         // Biblical Terms
-                        new() { Header = "🕮 " + _localizationService!.Get("MainView_WindowsBiblicalTerms"), Id = "BiblicalTermsID", ViewModel = this, },
+                        new() { Header = "🕮 " + _localizationService!.Get("MainView_WindowsBiblicalTerms"), Id = MenuIds.BiblicalTerms, ViewModel = this, },
                         
                         // Enhanced Corpus
-                        new() { Header = "⳼ " +_localizationService!.Get("MainView_WindowsEnhancedView"), Id = "EnhancedCorpusID", ViewModel = this, },
+                        new() { Header = "⳼ " +_localizationService!.Get("MainView_WindowsEnhancedView"), Id = MenuIds.EnhancedCorpus, ViewModel = this, },
                         
                         // PINS
-                        new() { Header = "⍒ " + _localizationService!.Get("MainView_WindowsPINS"), Id = "PINSID", ViewModel = this, },
+                        new() { Header = "⍒ " + _localizationService!.Get("MainView_WindowsPINS"), Id = MenuIds.Pins, ViewModel = this, },
                         
                         // Text Collection
-                        new() { Header = "🗐 " +_localizationService!.Get("MainView_WindowsTextCollections"), Id = "TextCollectionID", ViewModel = this, },
+                        new() { Header = "🗐 " +_localizationService!.Get("MainView_WindowsTextCollections"), Id = MenuIds.TextCollection, ViewModel = this, },
                         
                         // Word Meanings
                         //new() { Header = "⌺ " + LocalizationStrings.Get("MainView_WindowsWordMeanings", Logger), Id = "WordMeaningsID", ViewModel = this, },
                         
                         // MARBLE
-                        new() { Header = "◕ " +_localizationService!.Get("MainView_WindowsMarble"), Id = "MarbleID", ViewModel = this, },
+                        new() { Header = "◕ " +_localizationService!.Get("MainView_WindowsMarble"), Id = MenuIds.Marble, ViewModel = this, },
 
                         // Notes
-                        new() { Header = "⌺ " +_localizationService!.Get("MainView_WindowsNotes"), Id = "NotesId", ViewModel = this, },
+                        new() { Header = "⌺ " +_localizationService!.Get("MainView_WindowsNotes"), Id = MenuIds.Notes, ViewModel = this, },
 
                     }
                 },
@@ -1262,7 +1178,7 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Main
                 // SETTINGS
                 new()
                 {
-                    Header = _localizationService!.Get("MainView_Settings"), Id =  "SettingsID", ViewModel = this,
+                    Header = _localizationService!.Get("MainView_Settings"), Id =  MenuIds.Settings, ViewModel = this,
                     //MenuItems = new BindableCollection<MenuItemViewModel>
                     //{
                     //    // Gather Logs
@@ -1273,19 +1189,19 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Main
                 // HELP
                 new()
                 {
-                    Header = _localizationService!.Get("MainView_Help"), Id =  "HelpID", ViewModel = this,
+                    Header = _localizationService!.Get("MainView_Help"), Id =  MenuIds.Help, ViewModel = this,
                     MenuItems = new BindableCollection<MenuItemViewModel>
                     {
                         // launch Getting Started Guide
-                        new() { Header = _localizationService!.Get("MainView_GettingStartedGuide"), Id = "GettingStartedGuideID", ViewModel = this, },
+                        new() { Header = _localizationService!.Get("MainView_GettingStartedGuide"), Id = MenuIds.GettingStartedGuide, ViewModel = this, },
 
                         // Gather Logs
-                        new() { Header = _localizationService!.Get("MainView_ShowLog"), Id = "ShowLogID", ViewModel = this, },
+                        new() { Header = _localizationService!.Get("MainView_ShowLog"), Id = MenuIds.ShowLog, ViewModel = this, },
 
                         // Gather Logs
-                        new() { Header = _localizationService!.Get("MainView_GatherLogs"), Id = "GatherLogsID", ViewModel = this, },
+                        new() { Header = _localizationService!.Get("MainView_GatherLogs"), Id = MenuIds.GatherLogs, ViewModel = this, },
                         // About
-                        new() { Header = _localizationService!.Get("MainView_About"), Id = "AboutID", ViewModel = this, },
+                        new() { Header = _localizationService!.Get("MainView_About"), Id = MenuIds.About, ViewModel = this, },
                     }
                 }
             };
@@ -1715,9 +1631,9 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Main
             // the user wants to add to the currently active window
             if (metadatum.IsNewWindow == false)
             {
-               
 
-              
+
+
                 if (dockableWindows.Count == 1)
                 {
                     await EnhancedViewModels.First().AddItem(metadatum, cancellationToken);
@@ -1775,27 +1691,125 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Main
 
         public async Task ExecuteMenuCommand(MenuItemViewModel menuItem)
         {
+
             if (!_longRunningTaskManager!.HasTasks())
             {
-                if (menuItem.Id == "NewID")
+                
+                if (menuItem.Id.StartsWith(MenuIds.ProjectLayout) || menuItem.Id.StartsWith(MenuIds.StandardLayout))
                 {
-                    StartupDialogViewModel.GoToSetup = true;
+                    LoadLayoutById(menuItem.Id);
+                    return;
                 }
-
-                var startupDialogViewModel = LifetimeScope!.Resolve<StartupDialogViewModel>();
-                startupDialogViewModel.MimicParatextConnection = true;
-
-                var result = await WindowManager!.ShowDialogAsync(startupDialogViewModel);
-
-                if (result == true)
+                else if (menuItem.Id == MenuIds.Separator)
                 {
-                    await OnDeactivateAsync(false, CancellationToken.None);
-                    NavigationService?.NavigateToViewModel<MainViewModel>(startupDialogViewModel.ExtraData);
-                    await OnInitializeAsync(CancellationToken.None);
-                    await OnActivateAsync(CancellationToken.None);
-                    await EventAggregator.PublishOnUIThreadAsync(new ProjectLoadCompleteMessage(true));
+                    // no op
+                    return;
+                }
+                else if (menuItem.Id == MenuIds.Save)
+                {
+                    GridIsVisible = Visibility.Visible;
+                    DeleteGridIsVisible = Visibility.Collapsed;
+                    return;
+                }
+                else if (menuItem.Id == MenuIds.Delete)
+                {
+                    DeleteGridIsVisible = Visibility.Visible;
+                    GridIsVisible = Visibility.Collapsed;
+                    return;
+                }
+                else if (menuItem.Id == MenuIds.NewEnhancedCorpus)
+                {
+                    await AddNewEnhancedView();
+                    return;
+                }
+                else if (menuItem.Id == MenuIds.GettingStartedGuide)
+                {
+                    LaunchGettingStartedGuide();
+                    return;
+                }
+                else if (menuItem.Id == MenuIds.ShowLog)
+                {
+                    ShowLogs();
+                    return;
+                }
+                else if (menuItem.Id == MenuIds.GatherLogs)
+                {
+                    GatherLogs();
+                    return;
+                }
+                else if (menuItem.Id == MenuIds.Settings)
+                {
+                    await this.WindowManager.ShowWindowAsync(new DashboardSettingsViewModel(), null, null);
+                    return;
+                }
+                else if (menuItem.Id == MenuIds.About)
+                {
+                    ShowAboutWindow();
+                    return;
+                }
+                else if (menuItem.Id == MenuIds.FileNew || menuItem.Id == MenuIds.FileOpen)
+                {
+                    if (menuItem.Id == MenuIds.FileNew)
+                    {
+                        StartupDialogViewModel.GoToSetup = true;
+                    }
+
+                    var startupDialogViewModel = LifetimeScope!.Resolve<StartupDialogViewModel>();
+                    startupDialogViewModel.MimicParatextConnection = true;
+
+                    var result = await WindowManager!.ShowDialogAsync(startupDialogViewModel);
+
+                    if (result == true)
+                    {
+                        await OnDeactivateAsync(false, CancellationToken.None);
+                        NavigationService?.NavigateToViewModel<MainViewModel>(startupDialogViewModel.ExtraData);
+                        await OnInitializeAsync(CancellationToken.None);
+                        await OnActivateAsync(CancellationToken.None);
+                        await EventAggregator.PublishOnUIThreadAsync(new ProjectLoadCompleteMessage(true));
+                    }
+
+                    return;
+
+                }
+                else
+                {
+                    switch (menuItem.Id)
+                    {
+                        case MenuIds.Layout:
+                            Console.WriteLine();
+                            break;
+                        case MenuIds.BiblicalTerms:
+                            WindowIdToLoad = WindowIds.BiblicalTerms;
+                            break;
+                        case MenuIds.EnhancedCorpus:
+                            WindowIdToLoad = WindowIds.EnhancedView;
+                            break;
+                        case MenuIds.Pins:
+                            WindowIdToLoad = WindowIds.Pins;
+                            break;
+                        //case MenuIds.WordMeanings":
+                        //     WindowIdToLoad = WindowIds.WordMeanings;
+                        //    break;
+                        case MenuIds.Marble:
+                            WindowIdToLoad = WindowIds.Marble;
+                            break;
+                        case MenuIds.TextCollection:
+                            WindowIdToLoad = WindowIds.TextCollection;
+                            break;
+                        case MenuIds.Notes:
+                            WindowIdToLoad = WindowIds.Notes;
+                            break;
+
+                        default:
+                            WindowIdToLoad = menuItem.Id;
+                            break;
+                    }
+
+                    UnhideWindow(WindowIdToLoad);
+                    return;
                 }
             }
+
         }
 
         #endregion // Methods
@@ -1892,7 +1906,7 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Main
         public Task HandleAsync(BackgroundTaskChangedMessage message, CancellationToken cancellationToken)
         {
             bool enable;
-            if (_longRunningTaskManager.Tasks.Count<=1 && message.Status.TaskLongRunningProcessStatus != LongRunningTaskStatus.Running)
+            if (_longRunningTaskManager.Tasks.Count <= 1 && message.Status.TaskLongRunningProcessStatus != LongRunningTaskStatus.Running)
             {
                 enable = true;
             }

--- a/src/ClearDashboard.Wpf.Application/ViewModels/Menus/MenuIds.cs
+++ b/src/ClearDashboard.Wpf.Application/ViewModels/Menus/MenuIds.cs
@@ -1,0 +1,36 @@
+﻿using ClearDashboard.DataAccessLayer.Models;
+
+namespace ClearDashboard.Wpf.Application.ViewModels.Menus;
+
+public static class MenuIds
+{
+    public const string About = "AboutID";
+    public const string BiblicalTerms = "BiblicalTermsID";
+    public const string Delete = "DeleteID";
+    public const string EnhancedCorpus = "EnhancedCorpusID";
+  
+    public const string File = "FileID";
+    public const string FileNew = "NewID";
+    public const string FileOpen = "OpenID";
+    public const string GatherLogs = "GatherLogsID";
+    public const string GettingStartedGuide = "GettingStartedGuideID";
+    public const string Help = "HelpID";
+    public const string Layout = "LayoutID";
+    public const string Marble = "MARBLEID";
+   
+    public const string NewEnhancedCorpus = "NewEnhancedCorpusID";
+    
+    public const string Notes = "NotesID";
+    public const string Pins = "PINSID";
+    public const string ProjectLayout = "ProjectLayout:";
+    public const string ReloadProject = "ReloadProjectID";
+    public const string Save = "SaveID";
+    public const string Settings = "SettingsID";
+    public const string Separator = "SeparatorID";
+    public const string StandardLayout = "StandardLayout";
+    public const string ShowLog = "ShowLogID";
+    public const string TextCollection = "TextCollectionID";
+    public const string Window = "WindowID";
+    public const string WordMeanings = "WordMeaningsID";
+
+}

--- a/src/ClearDashboard.Wpf.Application/ViewModels/Menus/MenuItemViewModel.cs
+++ b/src/ClearDashboard.Wpf.Application/ViewModels/Menus/MenuItemViewModel.cs
@@ -99,17 +99,7 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Menus
 
         private async void Execute()
         {
-            if (Id is "NewID" or "OpenID")
-            {
-                await ViewModel.ExecuteMenuCommand(this);
-                return;
-            }
-            if (ViewModel != null)
-            {
-                ViewModel.WindowIdToLoad = Id;
-            }
-
-
+            await ViewModel.ExecuteMenuCommand(this);
         }
     }
 }

--- a/src/ClearDashboard.Wpf.Application/ViewModels/Menus/WindowIds.cs
+++ b/src/ClearDashboard.Wpf.Application/ViewModels/Menus/WindowIds.cs
@@ -1,0 +1,12 @@
+﻿namespace ClearDashboard.Wpf.Application.ViewModels.Menus;
+
+public static class WindowIds
+{
+    public const string BiblicalTerms = "BIBLICALTERMS";
+    public const string EnhancedView = "ENHANCEDVIEW";
+    public const string Marble = "MARBLE";
+    public const string Notes = "NOTES";
+    public const string Pins = "PINS";
+    public const string TextCollection = "TEXTCOLLECTION";
+    public const string WordMeanings = "WORDMEANINGS";
+}


### PR DESCRIPTION
This PR refactors the code used to invoke menu commands to use a proper method instead of a property with side effects.  This allows for the proper use of async/await instead of calling * .Wait().