### PR TITLE
Di 177

### DIFF
--- a/src/ClearDashboard.Wpf.Application.Abstractions/Controls/ProjectDesignSurface/DesignSurfaceViewModel.cs
+++ b/src/ClearDashboard.Wpf.Application.Abstractions/Controls/ProjectDesignSurface/DesignSurfaceViewModel.cs
@@ -924,9 +924,9 @@ namespace ClearDashboard.Wpf.Application.Controls.ProjectDesignSurface
         /// <summary>
         /// Utility method to delete a connection from the view-model.
         /// </summary>
-        public void DeleteParallelCorpusConnection(ParallelCorpusConnectionViewModel parallelCorpusConnection)
+        public void DeleteParallelCorpusConnection(ParallelCorpusConnectionViewModel parallelCorpusConnection, bool isCurrentlyParallelizing = false)
         {
-            if (parallelCorpusConnection.ParallelCorpusId != null)
+            if (!isCurrentlyParallelizing)
             {
                 EventAggregator.PublishOnUIThreadAsync(new ParallelCorpusDeletedMessage(
                      SourceParatextId: parallelCorpusConnection.SourceConnector!.ParentNode!.ParatextProjectId,

--- a/src/ClearDashboard.Wpf.Application/ViewModels/Project/ProjectDesignSurfaceViewModel.cs
+++ b/src/ClearDashboard.Wpf.Application/ViewModels/Project/ProjectDesignSurfaceViewModel.cs
@@ -1087,7 +1087,7 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Project
                 {
                     if (dialogViewModel!.ProjectType == ParallelProjectType.WholeProcess)
                     {
-                        DesignSurfaceViewModel!.DeleteParallelCorpusConnection(newParallelCorpusConnection);
+                        DesignSurfaceViewModel!.DeleteParallelCorpusConnection(newParallelCorpusConnection, true);
                     }
                 }
             }


### PR DESCRIPTION
This is addressing how canceling a paralellization mid way through throws an error.  The issue is that when cancelling a paralellization mid way through the ParallelCorpusId is null, throwing an error on the `ParallelCorpusDeletedMessage` . Thankfully it's not necessary to send a `ParallelCorpusDeletedMessage` when cancelling a parallelization because there's nothing in the enhanced view to get rid for the parallel corpus.