### PR TITLE
Plugin doesn't reconnect when restarting Paratext

### DIFF
--- a/src/ClearDashboard.Wpf.Application.Abstractions/DashboardProjectManager.cs
+++ b/src/ClearDashboard.Wpf.Application.Abstractions/DashboardProjectManager.cs
@@ -84,14 +84,12 @@ public class DashboardProjectManager : ProjectManager
         {
             Logger.LogError("Paratext is not running, cannot connect to SignalR.");
             await PublishSignalRConnected(false);
-            //await Task.Delay(10);
             await ConfigureSignalRClient();
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, "An unexpected error occurred while trying to connect to Paratext.");
             await PublishSignalRConnected(false);
-            //await Task.Delay(10);
             await ConfigureSignalRClient();
         }
     }

--- a/src/ClearDashboard.Wpf.Application/ViewModels/Shell/ShellViewModel.cs
+++ b/src/ClearDashboard.Wpf.Application/ViewModels/Shell/ShellViewModel.cs
@@ -526,7 +526,7 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Shell
         #region EventAggregator message handling
         public async Task HandleAsync(ParatextConnectedMessage message, CancellationToken cancellationToken)
         {
-            if (message.Connected == false && Connected !=false)
+            if (!message.Connected && Connected) //play sound only when going from connected to not connected
             {
                 PlaySound.PlaySoundFromResource(SoundType.Disconnected);
             }

--- a/src/ClearDashboard.Wpf.Application/ViewModels/Startup/ProjectPickerViewModel.cs
+++ b/src/ClearDashboard.Wpf.Application/ViewModels/Startup/ProjectPickerViewModel.cs
@@ -741,8 +741,7 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Startup
         {
             while (!IsParatextRunning || !Connected)
             {
-                //Thread.Sleep(1000);
-                IsParatextRunning = await Task.Run(() => _paratextProxy.IsParatextRunning());//.ConfigureAwait(false);
+                IsParatextRunning = await Task.Run(() => _paratextProxy.IsParatextRunning());
             }
         }
 
@@ -963,7 +962,7 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Startup
 
         public async Task HandleAsync(ParatextConnectedMessage message, CancellationToken cancellationToken)
         {
-            if (message.Connected ==false && Connected==true)
+            if (!message.Connected && Connected) //only run when going from connected to not connected
             {
                 IsParatextRunning=false;
                 ListenForParatextStart();


### PR DESCRIPTION
see https://clearbible.atlassian.net/jira/software/c/projects/DI/issues/DI-188 for details on the bug itself.

The solution:

1. I changed `HandleSignalRConnectionClosed` to `HandleSignalRConnectionReconnecting`  because there was about a 5 second gap of time between shutting down paratext and when `HandleSignalRConnectionClosed` would run.  If the user tried to re-open paratext during that 5 second gap then the plugin wouldn't connect.  `HandleSignalRConnectionReconnecting` doesn't have that gap of time before running after shutting down Paratext.  

2. Before attempting to reconnect I added `HubConnection.Dispose();`