### PR TITLE
Plugin Disconnects when interacting with plugin window

### DIFF
--- a/src/ClearDashboard.WebApiParatextPlugin/MainWindow.cs
+++ b/src/ClearDashboard.WebApiParatextPlugin/MainWindow.cs
@@ -158,7 +158,6 @@ namespace ClearDashboard.WebApiParatextPlugin
         /// <param name="e"></param>
         protected override async void OnLeave(EventArgs e)
         {
-            //WebAppProxy?.Dispose();
 
             base.OnLeave(e);
         }


### PR DESCRIPTION
https://clearbible.atlassian.net/browse/DI-242

`OnLeave` runs when the plugin window loses focus.  This was causing the plugin to disconnect frequently but we weren't gettting any visual notification of the disconnection because of the problems outlined in DI-188.  

Should `WebAppProxy?.Dispose();` be run somewhere else if its not going to be run in `OnLeave` or is it not necessary?  perhaps in `WindowClosing`?