### PR TITLE
sorting grids complete on GenerateLicense

### DIFF
--- a/tools/GenerateLicenseKeyForDashboard/Views/ShellView.xaml
+++ b/tools/GenerateLicenseKeyForDashboard/Views/ShellView.xaml
@@ -847,6 +847,8 @@
                         </Grid.RowDefinitions>
 
                         <DataGrid
+                            x:Name="GridDashboardUsers"
+                            GridViewColumnHeader.Click="DashboardGridViewColumnHeaderClickedHandler"
                             Margin="10"
                             AlternatingRowBackground="LightBlue"
                             AutoGenerateColumns="False"
@@ -1101,6 +1103,8 @@
                         </Grid.RowDefinitions>
 
                         <DataGrid
+                            x:Name="GridGitLabUsers"
+                            GridViewColumnHeader.Click="GridViewColumnHeaderClickedHandler"
                             Margin="10"
                             AlternatingRowBackground="LightBlue"
                             AutoGenerateColumns="False"
@@ -1114,6 +1118,7 @@
                             ItemsSource="{Binding GitLabUsers}"
                             RowBackground="LightYellow"
                             SelectionMode="Extended"
+                            
                             VerticalScrollBarVisibility="Visible">
 
                             <DataGrid.ContextMenu>
@@ -1171,6 +1176,20 @@
                                     </DataGridTemplateColumn.CellTemplate>
                                 </DataGridTemplateColumn>
 
+                                <DataGridTemplateColumn>
+                                    <DataGridTemplateColumn.Header>
+                                        <TextBlock
+                                            FontSize="16"
+                                            Foreground="{StaticResource MaterialDesignLightBackground}"
+                                            Text="Organization" />
+                                    </DataGridTemplateColumn.Header>
+                                    <DataGridTemplateColumn.CellTemplate>
+                                        <DataTemplate>
+                                            <TextBlock Text="{Binding Organization}" />
+                                        </DataTemplate>
+                                    </DataGridTemplateColumn.CellTemplate>
+                                </DataGridTemplateColumn>
+                                
                                 <DataGridTemplateColumn>
                                     <DataGridTemplateColumn.Header>
                                         <TextBlock

--- a/tools/GenerateLicenseKeyForDashboard/Views/ShellView.xaml.cs
+++ b/tools/GenerateLicenseKeyForDashboard/Views/ShellView.xaml.cs
@@ -1,8 +1,11 @@
 ﻿using ClearDashboard.DataAccessLayer.Models.Common;
 using ClearDashboard.DataAccessLayer.Models.LicenseGenerator;
 using System;
+using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Data;
 
 namespace GenerateLicenseKeyForDashboard.Views
 {
@@ -11,6 +14,13 @@ namespace GenerateLicenseKeyForDashboard.Views
     /// </summary>
     public partial class ShellView : Window
     {
+
+        private string _lastHeaderClicked = null;
+        private ListSortDirection _lastDirection = ListSortDirection.Ascending;
+
+        private string _lastHeaderClickedDashboard = null;
+        private ListSortDirection _lastDirectionDashboard = ListSortDirection.Ascending;
+
         public ShellView()
         {
             InitializeComponent();
@@ -30,7 +40,7 @@ namespace GenerateLicenseKeyForDashboard.Views
 
             if (sender is DataGrid grid)
             {
-                var columnIndex = grid.CurrentColumn!=null ? grid.CurrentColumn.DisplayIndex : 6;
+                var columnIndex = grid.CurrentColumn != null ? grid.CurrentColumn.DisplayIndex : 6;
 
                 var cells = grid.SelectedCells;
                 if (cells.Count != 0)
@@ -61,7 +71,7 @@ namespace GenerateLicenseKeyForDashboard.Views
                     }
                 }
             }
-            
+
             Clipboard.SetText(copyText);
         }
 
@@ -78,7 +88,7 @@ namespace GenerateLicenseKeyForDashboard.Views
 
             if (sender is DataGrid grid)
             {
-                var columnIndex = grid.CurrentColumn!=null ? grid.CurrentColumn.DisplayIndex : 6;
+                var columnIndex = grid.CurrentColumn != null ? grid.CurrentColumn.DisplayIndex : 6;
 
                 var cells = grid.SelectedCells;
                 if (cells.Count != 0)
@@ -124,8 +134,106 @@ namespace GenerateLicenseKeyForDashboard.Views
                     }
                 }
             }
-            
+
             Clipboard.SetText(copyText);
+        }
+
+        /// <summary>
+        /// Handle the GitLab Users Grid
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void GridViewColumnHeaderClickedHandler(object sender, RoutedEventArgs e)
+        {
+            var column = e.OriginalSource as DataGridColumnHeader;
+
+            if (column == null)
+            {
+                return;
+            }
+
+            var textBlock = column.DataContext as TextBlock;
+
+            ICollectionView cvTasks = CollectionViewSource.GetDefaultView(GridGitLabUsers.ItemsSource);
+            if (cvTasks != null && cvTasks.CanSort == true)
+            {
+                cvTasks.SortDescriptions.Clear();
+                if (textBlock.Text == "GitLab Id")
+                {
+                    if (_lastHeaderClicked == textBlock.Text)
+                    {
+                        if (_lastDirection == ListSortDirection.Ascending)
+                        {
+                            _lastDirection = ListSortDirection.Descending;
+                        }
+                        else
+                        {
+                            _lastDirection = ListSortDirection.Ascending;
+                        }
+                    }
+
+                    cvTasks.SortDescriptions.Add(new SortDescription("Id", _lastDirection));
+                }
+                else
+                {
+                    if (_lastHeaderClicked == textBlock.Text)
+                    {
+                        if (_lastDirection == ListSortDirection.Ascending)
+                        {
+                            _lastDirection = ListSortDirection.Descending;
+                        }
+                        else
+                        {
+                            _lastDirection = ListSortDirection.Ascending;
+                        }
+                    }
+
+
+                    cvTasks.SortDescriptions.Add(new SortDescription(textBlock.Text, _lastDirection));
+                }
+
+            }
+
+            _lastHeaderClicked = textBlock.Text;
+        }
+
+        /// <summary>
+        /// Handle the Dashboard User's Grid
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void DashboardGridViewColumnHeaderClickedHandler(object sender, RoutedEventArgs e)
+        {
+            var column = e.OriginalSource as DataGridColumnHeader;
+
+            if (column == null)
+            {
+                return;
+            }
+
+            var textBlock = column.DataContext as TextBlock;
+
+            ICollectionView cvTasks = CollectionViewSource.GetDefaultView(GridDashboardUsers.ItemsSource);
+            if (cvTasks != null && cvTasks.CanSort == true)
+            {
+                cvTasks.SortDescriptions.Clear();
+
+                if (_lastHeaderClickedDashboard == textBlock.Text)
+                {
+                    if (_lastDirectionDashboard == ListSortDirection.Ascending)
+                    {
+                        _lastDirectionDashboard = ListSortDirection.Descending;
+                    }
+                    else
+                    {
+                        _lastDirectionDashboard = ListSortDirection.Ascending;
+                    }
+                }
+
+                cvTasks.SortDescriptions.Add(new SortDescription(textBlock.Text, _lastDirectionDashboard));
+            }
+
+            _lastHeaderClickedDashboard = textBlock.Text;
         }
     }
 }


### PR DESCRIPTION
Clicking on the column header will now allow the user to sort that column.  Multiple clicks on the same column will reverse the order.  Now showing the Organization too