### PR TITLE
Making Desing Surface Arrows Thicker

### DIFF
--- a/src/ClearDashboard.Wpf.Application/Views/Project/ProjectDesignSurfaceViewStyle.xaml
+++ b/src/ClearDashboard.Wpf.Application/Views/Project/ProjectDesignSurfaceViewStyle.xaml
@@ -273,13 +273,15 @@
 
             <!--  The connection is represented by a curved arrow.  -->
             <projectDesignSurface:CurvedArrow
+                ArrowHeadLength="14"
+                ArrowHeadWidth="14"
                 ConnectionId="{Binding Path=Id}"
                 Fill="{StaticResource ConnectionBrush}"
                 NodeSource="{Binding Path=SourceConnector}"
                 NodeTarget="{Binding Path=DestinationConnector}"
                 Points="{Binding Points}"
                 Stroke="{StaticResource ConnectionBrush}"
-                StrokeThickness="3">
+                StrokeThickness="6">
                 <projectDesignSurface:CurvedArrow.ContextMenu>
                     <ContextMenu Name="ContextMenu" ItemsSource="{Binding MenuItems}">
                         <ContextMenu.Resources>
@@ -355,6 +357,7 @@
                     HorizontalAlignment="Right"
                     VerticalAlignment="Top">
                     <Line
+                        IsHitTestVisible="False"
                         Stroke="Black"
                         StrokeThickness="1"
                         X1="0"


### PR DESCRIPTION
Previously they were so thin it was impossible to right click on anything except the head of the arrow.  I also made the line leading to the delete icon arrow no longer interfere with clicking on the arrows
![image](https://github.com/Clear-Bible/ClearDashboard/assets/60048070/a7ea4b24-6e0c-4940-8697-2e9400cc9ff7)
