### PR TITLE
showing update link

### DIFF
--- a/src/ClearDashboard.Wpf.Application/Views/Startup/ProjectPickerView.xaml
+++ b/src/ClearDashboard.Wpf.Application/Views/Startup/ProjectPickerView.xaml
@@ -880,7 +880,7 @@
                 <StackPanel>
                     <userControls:ReleaseNotesUserControl>
                         <!--  This DataTrigger was added to work around an issue where this control froze the UI.  See Jira DI 96  -->
-                        <userControls:ReleaseNotesUserControl.Style>
+                        <!--<userControls:ReleaseNotesUserControl.Style>
                             <Style TargetType="userControls:ReleaseNotesUserControl">
                                 <Setter Property="Visibility" Value="Visible" />
                                 <Style.Triggers>
@@ -889,7 +889,7 @@
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>
-                        </userControls:ReleaseNotesUserControl.Style>
+                        </userControls:ReleaseNotesUserControl.Style>-->
                     </userControls:ReleaseNotesUserControl>
                 </StackPanel>
             </StatusBarItem>


### PR DESCRIPTION
we no longer stop showing the update link when Paratext opens.  We did this in the past to prevent a screen freeze but now that may not be an issue anymore.

From #788 and #792