### PR TITLE
handling when user changes size of project picker

### DIFF
--- a/src/ClearDashboard.Wpf.Application/Views/Startup/ProjectPickerView.xaml
+++ b/src/ClearDashboard.Wpf.Application/Views/Startup/ProjectPickerView.xaml
@@ -19,6 +19,7 @@
     Height="800"
     MinWidth="886"
     MinHeight="594"
+    MaxWidth="1140"
     MaxHeight="800"
     d:DesignHeight="450"
     d:DesignWidth="800"


### PR DESCRIPTION
from #815

I wasn't able to make the ProjectPicker un-resizable since it isn't a window but rather a UserControl being displayed on a Page (the StartupDialogViewModel), both of which cannot be set to be set to be un-resizable.