### PR TITLE
fix for Dale's PIN bug

### DIFF
--- a/installer/DashboardInstaller.iss
+++ b/installer/DashboardInstaller.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "ClearDashboard"
-#define MyAppVersion "1.1.0.7"
+#define MyAppVersion "1.1.0.8"
 #define MyAppPublisher "Clear Bible, Inc."
 #define MyAppURL "https://www.clear.bible/"
 #define MyAppExeName "ClearDashboard.Wpf.Application.exe"

--- a/installer/codesign_exe.bat
+++ b/installer/codesign_exe.bat
@@ -69,7 +69,7 @@ echo code sign the WPF exe
 pause
 
 echo CompressXMLs in Resources folder
-..\tools\CompressXML\CompressXML\bin\Release\net5.0\CompressTreeXML.exe
+rem ..\tools\CompressXML\CompressXML\bin\Release\net5.0\CompressTreeXML.exe
 
 pause
 ::===================INNO Dashboard=====================

--- a/src/ClearDashboard.Aqua.Module.Tests/ClearDashboard.Aqua.Module.Tests.csproj
+++ b/src/ClearDashboard.Aqua.Module.Tests/ClearDashboard.Aqua.Module.Tests.csproj
@@ -4,9 +4,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <FileVersion>1.1.0.7</FileVersion>
-    <Version>1.1.0.7</Version>
-    <AssemblyVersion>1.1.0.7</AssemblyVersion>
+    <FileVersion>1.1.0.8</FileVersion>
+    <Version>1.1.0.8</Version>
+    <AssemblyVersion>1.1.0.8</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />

--- a/src/ClearDashboard.Aqua.Module/ClearDashboard.Aqua.Module.csproj
+++ b/src/ClearDashboard.Aqua.Module/ClearDashboard.Aqua.Module.csproj
@@ -3,9 +3,9 @@
     <TargetFramework>net7.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
-    <FileVersion>1.1.0.7</FileVersion>
-    <Version>1.1.0.7</Version>
-    <AssemblyVersion>1.1.0.7</AssemblyVersion>
+    <FileVersion>1.1.0.8</FileVersion>
+    <Version>1.1.0.8</Version>
+    <AssemblyVersion>1.1.0.8</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Caliburn.Micro" Version="4.0.212" />

--- a/src/ClearDashboard.Collaboration/ClearDashboard.Collaboration.csproj
+++ b/src/ClearDashboard.Collaboration/ClearDashboard.Collaboration.csproj
@@ -4,9 +4,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyName>ClearDashboard.Collaboration</AssemblyName>
-    <FileVersion>1.1.0.7</FileVersion>
-    <Version>1.1.0.7</Version>
-    <AssemblyVersion>1.1.0.7</AssemblyVersion>
+    <FileVersion>1.1.0.8</FileVersion>
+    <Version>1.1.0.8</Version>
+    <AssemblyVersion>1.1.0.8</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ClearBible.Engine" Version="2.0.16" />

--- a/src/ClearDashboard.Common/ClearDashboard.Common.csproj
+++ b/src/ClearDashboard.Common/ClearDashboard.Common.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyVersion>1.1.0.7</AssemblyVersion>
-    <FileVersion>1.1.0.7</FileVersion>
+    <AssemblyVersion>1.1.0.8</AssemblyVersion>
+    <FileVersion>1.1.0.8</FileVersion>
     <Company>Clear Bible, Inc</Company>
     <Product>ClearDashboard</Product>
     <Copyright>2022, Clear Bible, Inc</Copyright>
@@ -11,7 +11,7 @@
     <RepositoryUrl>https://github.com/Clear-Bible/ClearDashboard</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PlatformTarget>x64</PlatformTarget>
-    <Version>1.1.0.7</Version>
+    <Version>1.1.0.8</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <LangVersion>latest</LangVersion>

--- a/src/ClearDashboard.DAL.Alignment/ClearDashboard.DAL.Alignment.csproj
+++ b/src/ClearDashboard.DAL.Alignment/ClearDashboard.DAL.Alignment.csproj
@@ -7,9 +7,9 @@
     <RepositoryUrl>https://github.com/Clear-Bible/ClearEngine</RepositoryUrl>
     <Platforms>AnyCPU</Platforms>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.1.0.7</Version>
-    <FileVersion>1.1.0.7</FileVersion>
-    <AssemblyVersion>1.1.0.7</AssemblyVersion>
+    <Version>1.1.0.8</Version>
+    <FileVersion>1.1.0.8</FileVersion>
+    <AssemblyVersion>1.1.0.8</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ClearBible.Engine" Version="2.0.16" />

--- a/src/ClearDashboard.DAL.CQRS.Features/ClearDashboard.DAL.CQRS.Features.csproj
+++ b/src/ClearDashboard.DAL.CQRS.Features/ClearDashboard.DAL.CQRS.Features.csproj
@@ -4,9 +4,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Platforms>AnyCPU</Platforms>
-    <FileVersion>1.1.0.7</FileVersion>
-    <Version>1.1.0.7</Version>
-    <AssemblyVersion>1.1.0.7</AssemblyVersion>
+    <FileVersion>1.1.0.8</FileVersion>
+    <Version>1.1.0.8</Version>
+    <AssemblyVersion>1.1.0.8</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MediatR" Version="9.0.0" />

--- a/src/ClearDashboard.DAL.CQRS/ClearDashboard.DAL.CQRS.csproj
+++ b/src/ClearDashboard.DAL.CQRS/ClearDashboard.DAL.CQRS.csproj
@@ -5,9 +5,9 @@
     <Copyright>Copyright Clear Bible</Copyright>
     <PackageProjectUrl>https://github.com/Clear-Bible/ClearDashboard</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Clear-Bible/ClearDashboard</RepositoryUrl>
-    <FileVersion>1.1.0.7</FileVersion>
-    <Version>1.1.0.7</Version>
-    <AssemblyVersion>1.1.0.7</AssemblyVersion>
+    <FileVersion>1.1.0.8</FileVersion>
+    <Version>1.1.0.8</Version>
+    <AssemblyVersion>1.1.0.8</AssemblyVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <LangVersion>latest</LangVersion>

--- a/src/ClearDashboard.DAL.Data/ClearDashboard.DAL.Data.csproj
+++ b/src/ClearDashboard.DAL.Data/ClearDashboard.DAL.Data.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
     <RootNamespace>ClearDashboard.DataAccessLayer.Data</RootNamespace>
     <Platforms>AnyCPU</Platforms>
-    <FileVersion>1.1.0.7</FileVersion>
-    <Version>1.1.0.7</Version>
-    <AssemblyVersion>1.1.0.7</AssemblyVersion>
+    <FileVersion>1.1.0.8</FileVersion>
+    <Version>1.1.0.8</Version>
+    <AssemblyVersion>1.1.0.8</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="6.4.0" />

--- a/src/ClearDashboard.DAL.Interfaces/ClearDashboard.DAL.Interfaces.csproj
+++ b/src/ClearDashboard.DAL.Interfaces/ClearDashboard.DAL.Interfaces.csproj
@@ -4,9 +4,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Platforms>AnyCPU;x64</Platforms>
-    <FileVersion>1.1.0.7</FileVersion>
-    <Version>1.1.0.7</Version>
-    <AssemblyVersion>1.1.0.7</AssemblyVersion>
+    <FileVersion>1.1.0.8</FileVersion>
+    <Version>1.1.0.8</Version>
+    <AssemblyVersion>1.1.0.8</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClearDashboard.DAL.Models\ClearDashboard.DAL.Models.csproj" />

--- a/src/ClearDashboard.DAL.Models/ClearDashboard.DAL.Models.csproj
+++ b/src/ClearDashboard.DAL.Models/ClearDashboard.DAL.Models.csproj
@@ -6,13 +6,13 @@
     <LangVersion>Latest</LangVersion>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.1.0.7</Version>
+    <Version>1.1.0.8</Version>
     <Copyright>
     </Copyright>
     <PackageProjectUrl>https://github.com/Clear-Bible/ClearDashboard</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Clear-Bible/ClearDashboard</RepositoryUrl>
-    <FileVersion>1.1.0.7</FileVersion>
-    <AssemblyVersion>1.1.0.7</AssemblyVersion>
+    <FileVersion>1.1.0.8</FileVersion>
+    <AssemblyVersion>1.1.0.8</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Common\SelectedBook.cs" />

--- a/src/ClearDashboard.DAL.ViewModels/ClearDashboard.DAL.ViewModels.csproj
+++ b/src/ClearDashboard.DAL.ViewModels/ClearDashboard.DAL.ViewModels.csproj
@@ -3,9 +3,9 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <FileVersion>1.1.0.7</FileVersion>
-    <Version>1.1.0.7</Version>
-    <AssemblyVersion>1.1.0.7</AssemblyVersion>
+    <FileVersion>1.1.0.8</FileVersion>
+    <Version>1.1.0.8</Version>
+    <AssemblyVersion>1.1.0.8</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Caliburn.Micro.Core" Version="4.0.212" />

--- a/src/ClearDashboard.DAL/ClearDashboard.DAL.csproj
+++ b/src/ClearDashboard.DAL/ClearDashboard.DAL.csproj
@@ -6,11 +6,11 @@
     <Nullable>enable</Nullable>
     <Platforms>AnyCPU</Platforms>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.1.0.7</Version>
+    <Version>1.1.0.8</Version>
     <PackageProjectUrl>https://github.com/Clear-Bible/ClearDashboard</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Clear-Bible/ClearDashboard</RepositoryUrl>
-    <FileVersion>1.1.0.7</FileVersion>
-    <AssemblyVersion>1.1.0.7</AssemblyVersion>
+    <FileVersion>1.1.0.8</FileVersion>
+    <AssemblyVersion>1.1.0.8</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Models\**" />

--- a/src/ClearDashboard.ParatextPlugin.CQRS/ClearDashboard.ParatextPlugin.CQRS.csproj
+++ b/src/ClearDashboard.ParatextPlugin.CQRS/ClearDashboard.ParatextPlugin.CQRS.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyVersion>1.1.0.7</AssemblyVersion>
-    <FileVersion>1.1.0.7</FileVersion>
+    <AssemblyVersion>1.1.0.8</AssemblyVersion>
+    <FileVersion>1.1.0.8</FileVersion>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <Version>1.1.0.7</Version>
+    <Version>1.1.0.8</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <LangVersion>latest</LangVersion>

--- a/src/ClearDashboard.ParatextPlugin/ClearDashboard.ParatextPlugin.csproj
+++ b/src/ClearDashboard.ParatextPlugin/ClearDashboard.ParatextPlugin.csproj
@@ -3,9 +3,9 @@
     <TargetFramework>net472</TargetFramework>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
     <PlatformTarget>x64</PlatformTarget>
-    <FileVersion>1.1.0.7</FileVersion>
-    <Version>1.1.0.7</Version>
-    <AssemblyVersion>1.1.0.7</AssemblyVersion>
+    <FileVersion>1.1.0.8</FileVersion>
+    <Version>1.1.0.8</Version>
+    <AssemblyVersion>1.1.0.8</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Plugin.bmp" />

--- a/src/ClearDashboard.Sample.Module/ClearDashboard.Sample.Module.csproj
+++ b/src/ClearDashboard.Sample.Module/ClearDashboard.Sample.Module.csproj
@@ -3,9 +3,9 @@
     <TargetFramework>net7.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
-    <FileVersion>1.1.0.7</FileVersion>
-    <Version>1.1.0.7</Version>
-    <AssemblyVersion>1.1.0.7</AssemblyVersion>
+    <FileVersion>1.1.0.8</FileVersion>
+    <Version>1.1.0.8</Version>
+    <AssemblyVersion>1.1.0.8</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Caliburn.Micro" Version="4.0.212" />

--- a/src/ClearDashboard.Tests/ClearDashboard.Tests.csproj
+++ b/src/ClearDashboard.Tests/ClearDashboard.Tests.csproj
@@ -4,9 +4,9 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <PlatformTarget>x64</PlatformTarget>
-    <FileVersion>1.1.0.7</FileVersion>
-    <Version>1.1.0.7</Version>
-    <AssemblyVersion>1.1.0.7</AssemblyVersion>
+    <FileVersion>1.1.0.8</FileVersion>
+    <Version>1.1.0.8</Version>
+    <AssemblyVersion>1.1.0.8</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />

--- a/src/ClearDashboard.WPF.Tests/ClearDashboard.WPF.Tests.csproj
+++ b/src/ClearDashboard.WPF.Tests/ClearDashboard.WPF.Tests.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <Platforms>AnyCPU</Platforms>
-    <FileVersion>1.1.0.7</FileVersion>
-    <Version>1.1.0.7</Version>
-    <AssemblyVersion>1.1.0.7</AssemblyVersion>
+    <FileVersion>1.1.0.8</FileVersion>
+    <Version>1.1.0.8</Version>
+    <AssemblyVersion>1.1.0.8</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Clear.SIL.Machine" Version="2.5.14" />

--- a/src/ClearDashboard.WPF/ClearDashboard.Wpf.csproj
+++ b/src/ClearDashboard.WPF/ClearDashboard.Wpf.csproj
@@ -5,12 +5,12 @@
     <UseWPF>true</UseWPF>
     <PackageIcon>ClearDashboard_logo_128.png</PackageIcon>
     <ApplicationIcon>Assets\ClearDashboard_logo.ico</ApplicationIcon>
-    <AssemblyVersion>1.1.0.7</AssemblyVersion>
-    <FileVersion>1.1.0.7</FileVersion>
+    <AssemblyVersion>1.1.0.8</AssemblyVersion>
+    <FileVersion>1.1.0.8</FileVersion>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <LangVer>latest</LangVer>
     <Platforms>AnyCPU</Platforms>
-    <Version>1.1.0.7</Version>
+    <Version>1.1.0.8</Version>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Stores\**" />

--- a/src/ClearDashboard.WebApiParatextPlugin/ClearDashboard.WebApiParatextPlugin.csproj
+++ b/src/ClearDashboard.WebApiParatextPlugin/ClearDashboard.WebApiParatextPlugin.csproj
@@ -4,9 +4,9 @@
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
-    <Version>1.1.0.7</Version>
-    <FileVersion>1.1.0.7</FileVersion>
-    <AssemblyVersion>1.1.0.7</AssemblyVersion>
+    <Version>1.1.0.8</Version>
+    <FileVersion>1.1.0.8</FileVersion>
+    <AssemblyVersion>1.1.0.8</AssemblyVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <LangVersion>9</LangVersion>

--- a/src/ClearDashboard.Wpf.Application.Abstractions/ClearDashboard.Wpf.Application.Abstractions.csproj
+++ b/src/ClearDashboard.Wpf.Application.Abstractions/ClearDashboard.Wpf.Application.Abstractions.csproj
@@ -12,10 +12,10 @@
     <PackageIcon>ClearDashboard_logo_100.png</PackageIcon>
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>1.1.0.7</Version>
+    <Version>1.1.0.8</Version>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <FileVersion>1.1.0.7</FileVersion>
-    <AssemblyVersion>1.1.0.7</AssemblyVersion>
+    <FileVersion>1.1.0.8</FileVersion>
+    <AssemblyVersion>1.1.0.8</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\ClearDashboard.Wpf.Application\Assets\ClearDashboard_logo_100.png">

--- a/src/ClearDashboard.Wpf.Application/ClearDashboard.Wpf.Application.csproj
+++ b/src/ClearDashboard.Wpf.Application/ClearDashboard.Wpf.Application.csproj
@@ -7,9 +7,9 @@
     <Platforms>AnyCPU;x64</Platforms>
     <ApplicationIcon>Assets\ClearDashboard_Icon.ico</ApplicationIcon>
     <Copyright>Clear Bible, 2023</Copyright>
-    <AssemblyVersion>1.1.0.7</AssemblyVersion>
-    <FileVersion>1.1.0.7</FileVersion>
-    <Version>1.1.0.7</Version>
+    <AssemblyVersion>1.1.0.8</AssemblyVersion>
+    <FileVersion>1.1.0.8</FileVersion>
+    <Version>1.1.0.8</Version>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <UserSecretsId>b02febcf-d7fc-48e1-abb1-f03647ca553c</UserSecretsId>
     <Configurations>Debug;Release;Collab_Release;Collab_Debug</Configurations>

--- a/src/ClearDashboard.Wpf.Application/ViewModels/ParatextViews/PinsViewModel.cs
+++ b/src/ClearDashboard.Wpf.Application/ViewModels/ParatextViews/PinsViewModel.cs
@@ -641,7 +641,13 @@ namespace ClearDashboard.Wpf.Application.ViewModels.ParatextViews
                     var verseList = new List<string>();
 
                     // check against the BiblicalTermsList
-                    var bt = _biblicalTermsList.Term.FindAll(t => t.Id == sourceWord);
+                    var bt = _biblicalTermsList.Term?.FindAll(t => t.Id == sourceWord);
+
+                    if (bt is null)
+                    {
+                        bt = new List<Term>();
+                    }
+
                     var gloss = "";
                     if (bt.Count > 0)
                     {
@@ -683,7 +689,13 @@ namespace ClearDashboard.Wpf.Application.ViewModels.ParatextViews
                     else
                     {
                         // if not found in the Biblical Terms list, now check AllBiblicalTerms second
-                        var abt = _allBiblicalTermsList.Term.FindAll(t => t.Id == sourceWord);
+                        var abt = _allBiblicalTermsList.Term?.FindAll(t => t.Id == sourceWord);
+                        if (abt is null)
+                        {
+                            abt = new List<Term>();
+                        }
+
+
                         if (abt.Count > 0)
                         {
                             gloss = abt[0].Gloss;

--- a/src/ClearDashboard.Wpf.Application/app.manifest
+++ b/src/ClearDashboard.Wpf.Application/app.manifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.1.0.7" name="ClearDashboard.Wpf.Application.app"/>
+  <assemblyIdentity version="1.1.0.8" name="ClearDashboard.Wpf.Application.app"/>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/src/ClearDashboard.Wpf.Controls/ClearDashboard.Wpf.Controls.csproj
+++ b/src/ClearDashboard.Wpf.Controls/ClearDashboard.Wpf.Controls.csproj
@@ -5,9 +5,9 @@
     <UseWPF>true</UseWPF>
     <Platforms>AnyCPU</Platforms>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.1.0.7</Version>
-    <FileVersion>1.1.0.7</FileVersion>
-    <AssemblyVersion>1.1.0.7</AssemblyVersion>
+    <Version>1.1.0.8</Version>
+    <FileVersion>1.1.0.8</FileVersion>
+    <AssemblyVersion>1.1.0.8</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Caliburn.Micro.Core" Version="4.0.212" />


### PR DESCRIPTION
PINS: PINS Failed:

System.NullReferenceException: Object reference not set to an instance of an object.

   at ClearDashboard.Wpf.Application.ViewModels.ParatextViews.PinsViewModel.<>c__DisplayClass112_0.<<GenerateData>b__0>d.MoveNext() in C:\Users\rober\Documents\GitHub\ClearDashboard\src\ClearDashboard.Wpf.Application\ViewModels\ParatextViews\PinsViewModel.cs:line 644

--- End of stack trace from previous location ---

   at ClearDashboard.Wpf.Application.ViewModels.ParatextViews.PinsViewModel.GenerateData(CancellationToken cancellationToken) in C:\Users\rober\Documents\GitHub\ClearDashboard\src\ClearDashboard.Wpf.Application\ViewModels\ParatextViews\PinsViewModel.cs:line 508

   at ClearDashboard.Wpf.Application.ViewModels.ParatextViews.PinsViewModel.Initialize(CancellationToken cancellationToken) in C:\Users\rober\Documents\GitHub\ClearDashboard\src\ClearDashboard.Wpf.Application\ViewModels\ParatextViews\PinsViewModel.cs:line 409