### PR TITLE
fix notes verse association bug

### DIFF
--- a/src/ClearDashboard.Wpf.Application.Abstractions/ViewModels/EnhancedView/NoteViewModel.cs
+++ b/src/ClearDashboard.Wpf.Application.Abstractions/ViewModels/EnhancedView/NoteViewModel.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Caliburn.Micro;
 using ClearBible.Engine.Utils;
 using ClearDashboard.DAL.Alignment.Notes;
+using ClearDashboard.DAL.Alignment.Translation;
 using ClearDashboard.Wpf.Application.Collections;
 using ClearDashboard.Wpf.Application.Models;
 using ClearDashboard.Wpf.Application.ViewModels.EnhancedView;
@@ -73,7 +74,16 @@ namespace ClearDashboard.Wpf.Application.ViewModels.EnhancedView
                 {
                     try
                     {
-                        var verseId = association.AssociatedEntityId.ToString().Substring(0,9);
+                        var verseId = string.Empty;
+                        if (association.AssociatedEntityId is TranslationId translationId)
+                        {
+                            verseId = translationId.SourceTokenId.ToString().Substring(0, 9);
+                        }
+                        else
+                        {
+                            verseId = association.AssociatedEntityId.ToString().Substring(0, 9);
+                        }
+
                         if (verseId.Length > 0)
                         {
                             verses += DAL.ViewModels.BookChapterVerseViewModel.GetVerseStrShortFromBBBCCCVVV(verseId) + ", ";


### PR DESCRIPTION
from #830 

we need to use 
`association.AssociatedEntityId.SourceTokenId.ToString()` rather than 
`association.AssociatedEntityId.ToString()`
since `association.AssociatedEntityId.ToString()` is just the name of an object and not the actual token id.

instead of using `association.AssociatedEntityId.SourceTokenId.ToString()` all the time I put it behind a check in case it was null (it's marked as nullable).