### PR TITLE
Books not present in a Paratext Project are no longer selectable

### DIFF
--- a/src/ClearDashboard.Wpf.Application.Abstractions/Services/SelectedBookManager.cs
+++ b/src/ClearDashboard.Wpf.Application.Abstractions/Services/SelectedBookManager.cs
@@ -86,7 +86,7 @@ public class SelectedBookManager : PropertyChangedBase
 
     private async Task<IEnumerable<SelectedBook>> InitializeBooksInternal(IEnumerable<UsfmError>? usfmErrors, string paratextProjectId, bool enableTokenizedBooks, CancellationToken cancellationToken)
     {
-        var books = CreateBooks(true);
+        var books = CreateBooks();
 
         // get those books which actually have text in them from Paratext
         var requestFromParatext = await _mediator.Send(new GetVersificationAndBookIdByParatextProjectIdQuery(paratextProjectId), cancellationToken);


### PR DESCRIPTION
from #861

books not present in a paratext project are now unable to be selected:

ZINZA Before:
![image](https://github.com/Clear-Bible/ClearDashboard/assets/60048070/36050c4f-ebd9-40e9-8143-a4447245eb1e)

ZINZA After:
![image](https://github.com/Clear-Bible/ClearDashboard/assets/60048070/2314eff2-139b-4fd0-aef0-90689612598b)
