### PR TITLE
Enabling Menu Items after Update from Paratext

### DIFF
--- a/src/ClearDashboard.Wpf.Application/ViewModels/Project/ProjectDesignSurfaceViewModel.cs
+++ b/src/ClearDashboard.Wpf.Application/ViewModels/Project/ProjectDesignSurfaceViewModel.cs
@@ -1181,9 +1181,6 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Project
                                 cancellationToken
                             );
 
-                            await SendBackgroundStatus(taskName, LongRunningTaskStatus.Completed,
-                               description: $"Updating verses in tokenized text corpus for '{selectedProject.Name}' corpus...Completed", cancellationToken: cancellationToken);
-
                             var tokenizedTextCorpusId = (await TokenizedTextCorpus.GetAllTokenizedCorpusIds(
                                     Mediator!,
                                     new CorpusId(node.CorpusId)))
@@ -1202,6 +1199,9 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Project
                             await EventAggregator.PublishOnUIThreadAsync(new TokenizedCorpusUpdatedMessage(tokenizedTextCorpusId), cancellationToken);
 
                             _longRunningTaskManager.TaskComplete(taskName);
+
+                            await SendBackgroundStatus(taskName, LongRunningTaskStatus.Completed,
+                                description: $"Updating verses in tokenized text corpus for '{selectedProject.Name}' corpus...Completed", cancellationToken: cancellationToken);
                         }
                         catch (OperationCanceledException)
                         {

--- a/src/ClearDashboard.Wpf.Application/ViewModels/Shell/BackgroundTasksViewModel.cs
+++ b/src/ClearDashboard.Wpf.Application/ViewModels/Shell/BackgroundTasksViewModel.cs
@@ -157,10 +157,6 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Shell
 
         public async Task HandleAsync(BackgroundTaskChangedMessage message, CancellationToken cancellationToken)
         {
-            if (message.Status.TaskLongRunningProcessStatus == LongRunningTaskStatus.Completed)
-            {
-                _longRunningTaskManager.TaskComplete(message.Status.Name);
-            }
 
             var backgroundTaskStatus = message.Status;
 


### PR DESCRIPTION
from bethany feedback on #813 

After pulling in changes from Paratext, certain menu items were disabled.  This was because `BackgroundTasksViewModel` was being updated before `LongRunningTaskManager.Tasks`.  The order is important since the menu item enabling/disabling is dealt with in an IHandle<BackgroundTaskChangedMessage> but is dependent on data from the LongRunningTaskManager.

An alternative solution would involve more tightly intertwining BackgroundTasks and LongRunningTasks (which may be desirable?).
