### PR TITLE
Only Clearing Out ProjectName at Appropriate Time

### DIFF
--- a/src/ClearDashboard.Wpf.Application/ViewModels/Startup/ProjectTemplate/BuildProjectStepViewModel.cs
+++ b/src/ClearDashboard.Wpf.Application/ViewModels/Startup/ProjectTemplate/BuildProjectStepViewModel.cs
@@ -713,6 +713,8 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Startup.ProjectTemplate
                 _processRunner.Cancel();
 
                 await Task.WhenAny(tasks: new[] { _runningTask, Task.Delay(30000) });
+
+                ParentViewModel!.ProjectName = string.Empty;
             }
             else
             {

--- a/src/ClearDashboard.Wpf.Application/ViewModels/Startup/ProjectTemplate/ProjectSelectionStepViewModel.cs
+++ b/src/ClearDashboard.Wpf.Application/ViewModels/Startup/ProjectTemplate/ProjectSelectionStepViewModel.cs
@@ -144,7 +144,7 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Startup.ProjectTemplate
 
         protected override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
-            ProjectName = string.Empty; 
+            ProjectName = ParentViewModel.ProjectName ?? string.Empty; 
 
             await Initialize(cancellationToken);
             await base.OnActivateAsync(cancellationToken);
@@ -355,6 +355,7 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Startup.ProjectTemplate
         public override async Task MoveBackwardsAction()
         {
             ProjectName = string.Empty;
+            ParentViewModel.ProjectName = ProjectName;
             ParentViewModel!.Reset();
             await ParentViewModel!.GoToStep(1);
         }


### PR DESCRIPTION
From #900 

Rather than setting ProjectName to string.Empty everytime the ProjectSelectionStepViewModel actives, ProjectName is set to the value of ParentViewModel.ProjectName.  ParentViewModel.ProjectName is then set to string.Empty only when Cancelling mid-project-creation or when leaving the template to go back to the ProjectPicker