### PR TITLE
Properly reloading the "Import" DataGrid

### DIFF
--- a/src/ClearDashboard.Wpf.Application/ViewModels/Lexicon/LexiconViewModel.cs
+++ b/src/ClearDashboard.Wpf.Application/ViewModels/Lexicon/LexiconViewModel.cs
@@ -263,12 +263,13 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Lexicon
                     await LexiconManager.ProcessImportedLexicon();
 
                     //SelectedProjectCorpus = null;
-                    LexiconImports.Clear();
-                    NotifyOfPropertyChange(()=>HasLexiconImports);
-                    NotifyOfPropertyChange(() => ShowNoRecordsToManageMessage);
+                    //LexiconImports.Clear();
+                    //NotifyOfPropertyChange(()=>HasLexiconImports);
+                    //NotifyOfPropertyChange(() => ShowNoRecordsToManageMessage);
                     
 
                     await GetImportedLexiconViewModels(CancellationToken.None);
+                    await GetLexiconImportViewModels(CancellationToken.None);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
This PR fixes an issue where the "Import" datagrid was not properly re-loaded after importing checked rows.