### PR TITLE
Issues with Token Selection

### DIFF
--- a/src/ClearDashboard.Wpf.Application/UserControls/VerseDisplay.xaml.cs
+++ b/src/ClearDashboard.Wpf.Application/UserControls/VerseDisplay.xaml.cs
@@ -793,10 +793,10 @@ namespace ClearDashboard.Wpf.Application.UserControls
                     EnhancedFocusScope.SetFocusOnActiveElementInScope(element);
                 }
 
-                if (!args.IsShiftPressed && !args.IsAltPressed && Mouse.LeftButton == MouseButtonState.Pressed)
-                {
-                    UpdateVerseSelection(args.TokenDisplay, true);
-                }
+                //if (!args.IsShiftPressed && !args.IsAltPressed && Mouse.LeftButton == MouseButtonState.Pressed)
+                //{
+                //    UpdateVerseSelection(args.TokenDisplay, true);
+                //}
             }
 
             RaiseTokenEvent(TokenMouseEnterEvent, e);


### PR DESCRIPTION
from #917 

Steps to Reproduce:
1. right-click on an unselected token
2. left-click on any token

Expected Result: 

- The token is selected

Actual Result: 

- The token is selected briefly and then is unselected

After right-clicking a token, left-clicking it causes OnTokenMouseEnter to trigger twice.  I'm not sure why.  The second time OnTokenMouseEnter triggers it unselects the token.  

Removing this code seemed to make token selection work properly.  What is the purpose of this code?  Is there a better way to solve this issue?
  