### PR TITLE
Fixed issue with showing alignment data in the DataGrid on the Alignments card in the Bulk Alignment editor

### DIFF
--- a/src/ClearDashboard.Wpf.Application/UserControls/BulkAlignment/AlignmentApproval.xaml
+++ b/src/ClearDashboard.Wpf.Application/UserControls/BulkAlignment/AlignmentApproval.xaml
@@ -78,8 +78,8 @@
                 SelectionMode="Single"
                 SelectionUnit="FullRow"
                 VirtualizingPanel.IsVirtualizing="True"
-                VirtualizingPanel.IsVirtualizingWhenGrouping="True"
-                VirtualizingPanel.VirtualizationMode="Recycling">
+                VirtualizingPanel.IsVirtualizingWhenGrouping="False"
+                VirtualizingPanel.VirtualizationMode="Standard">
                 <DataGrid.Columns>
                     <DataGridTemplateColumn>
                         <DataGridTemplateColumn.HeaderTemplate>

--- a/src/ClearDashboard.Wpf.Application/UserControls/ReadOnlyVerseDisplay.xaml
+++ b/src/ClearDashboard.Wpf.Application/UserControls/ReadOnlyVerseDisplay.xaml
@@ -13,8 +13,7 @@
     d:DesignWidth="800"
     mc:Ignorable="d">
 
-    <UserControl.Resources>
-        <converters:BoolFlowDirectionConverter x:Key="BoolFlowDirectionConverter" />
+    <userControls:VerseDisplayBase.Resources>
         <DataTemplate x:Key="SourceTokenDisplay">
             <userControls:ReadOnlyTokenDisplay
                 HorizontalAlignment="Left"
@@ -41,7 +40,7 @@
         <ItemsPanelTemplate x:Key="TargetWrapPanelTemplate">
             <WrapPanel FlowDirection="{Binding ElementName=VerseDisplayControl, Path=TargetFlowDirection}" Orientation="Horizontal" />
         </ItemsPanelTemplate>
-    </UserControl.Resources>
+    </userControls:VerseDisplayBase.Resources>
 
     <StackPanel Orientation="Vertical">
         <Border
@@ -54,7 +53,7 @@
                 FlowDirection="{Binding ElementName=VerseDisplayControl, Path=SourceFlowDirection}"
                 ItemTemplate="{StaticResource SourceTokenDisplay}"
                 ItemsPanel="{StaticResource SourceWrapPanelTemplate}"
-                ItemsSource="{Binding RelativeSource={RelativeSource AncestorType={x:Type userControls:VerseDisplayBase}}, Path=SourceTokens}" />
+                ItemsSource="{Binding ElementName=VerseDisplayControl, Path=SourceTokens}" />
         </Border>
         <Border
             Margin="{Binding ElementName=VerseDisplayControl, Path=VerseMargin}"
@@ -67,8 +66,7 @@
                 FlowDirection="{Binding ElementName=VerseDisplayControl, Path=TargetFlowDirection}"
                 ItemTemplate="{StaticResource TargetTokenDisplay}"
                 ItemsPanel="{StaticResource TargetWrapPanelTemplate}"
-                ItemsSource="{Binding RelativeSource={RelativeSource AncestorType={x:Type userControls:VerseDisplayBase}}, Path=TargetTokens}"
-                />
+                ItemsSource="{Binding ElementName=VerseDisplayControl, Path=TargetTokens}"/>
         </Border>
     </StackPanel>
 </userControls:VerseDisplayBase>


### PR DESCRIPTION
The issue was due to how virtualization on the DataGrid was defined. Switching the VirtualizationMode from Recycling to Stand resolved the issue.