### PR TITLE
Prevent Usfm error book Inclusion

### DIFF
--- a/src/ClearDashboard.Wpf.Application.Abstractions/Services/SelectedBookManager.cs
+++ b/src/ClearDashboard.Wpf.Application.Abstractions/Services/SelectedBookManager.cs
@@ -62,6 +62,7 @@ public class SelectedBookManager : PropertyChangedBase
                 {
                     commonBooks[book.Abbreviation].IsEnabled = commonBooks[book.Abbreviation].IsEnabled || book.IsEnabled;
                 }
+                commonBooks[book.Abbreviation].IsEnabled = (commonBooks[book.Abbreviation].IsEnabled && !book.HasUsfmError);
                 commonBooks[book.Abbreviation].IsSelected = false; // set this to false by default
             }
         }


### PR DESCRIPTION
In the case that someone is making a project using the startup wizard and either his BackTranslation or LWC corpus has errors, this will prevent those books from being imported.