### PR TITLE
manually clear our labels when making a new note

### DIFF
--- a/src/ClearDashboard.Wpf.Application/ViewModels/EnhancedView/EnhancedViewModel.cs
+++ b/src/ClearDashboard.Wpf.Application/ViewModels/EnhancedView/EnhancedViewModel.cs
@@ -1001,6 +1001,8 @@ namespace ClearDashboard.Wpf.Application.ViewModels.EnhancedView
         {
             await Execute.OnUIThreadAsync(async () =>
             {
+                //TODO This is a TEMPORAY FIX just for the hotfix, this needs to be resolved by ANDY in the longterm
+                e.Note.Labels.Clear();
                 await NoteManager.AddNoteAsync(e.Note, e.EntityIds);
                 NotifyOfPropertyChange(() => Items);
             });


### PR DESCRIPTION
From #1001

Problem: Newly created notes have the labels of the note made immediately before

Reproduce:
1. Make a Note
2. Make a label
3. Make another Note
4. Notice that the new note has the label from the note made in step 1

@blackcrater Is this the problem you meant when you said 
> One additional consideration here: the user's last-used label group is persisted and defaulted.  Thus if the user previously set something other than "None," there'd be no UI to change it back without the combo box.

This is a TEMPORAY FIX just for the hotfix, this needs to be resolved in the longterm.

Is this a sufficient way of implementing the hotfix or will it be more problematic?

