### PR TITLE
auto checkbox when new text in Set Gloss is entered

### DIFF
--- a/src/ClearDashboard.Wpf.Application/UserControls/Lexicon/ConcordanceDisplay.xaml
+++ b/src/ClearDashboard.Wpf.Application/UserControls/Lexicon/ConcordanceDisplay.xaml
@@ -79,7 +79,6 @@
                 FontSize="{Binding RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Path=TranslationFontSize}"
                 FontStyle="{Binding RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Path=TranslationFontStyle}"
                 FontWeight="{Binding RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Path=TranslationFontWeight}"
-                IsEnabled="{Binding RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Path=NewTranslationTextBoxIsEnabled}"
                 KeyUp="OnNewTranslationTextBoxKeyUp"
                 TextChanged="OnNewTranslationChanged" />
             <TextBlock

--- a/src/ClearDashboard.Wpf.Application/UserControls/Lexicon/ConcordanceDisplay.xaml.cs
+++ b/src/ClearDashboard.Wpf.Application/UserControls/Lexicon/ConcordanceDisplay.xaml.cs
@@ -171,6 +171,7 @@ namespace ClearDashboard.Wpf.Application.UserControls.Lexicon
         
         private void OnNewTranslationChanged(object sender, RoutedEventArgs e)
         {
+            NewTranslationCheckBox.IsChecked = true;
             RaiseTranslationEntryEvent(NewTranslationChangedEvent, new LexiconTranslationViewModel { Text = NewTranslationTextBox.Text });
         }
 


### PR DESCRIPTION
Textbox goes from disabled by default to enabled and when text changes, the appropriate radio button gets auto checked

From this:
![image](https://github.com/Clear-Bible/ClearDashboard/assets/1356726/28300816-edb8-4035-9f29-9f61e6a4e73c)

To this when new text is entered:
![image](https://github.com/Clear-Bible/ClearDashboard/assets/1356726/91bd391f-5817-48d7-9268-a2d9d75bad6f)

![image](https://github.com/Clear-Bible/ClearDashboard/assets/1356726/f9386695-3979-4b2d-85ae-09c4a6232b61)
