### PR TITLE
add loading wheel to project picker

### DIFF
--- a/src/ClearDashboard.Wpf.Application/UserControls/AlignmentBulkReview.xaml
+++ b/src/ClearDashboard.Wpf.Application/UserControls/AlignmentBulkReview.xaml
@@ -2,7 +2,6 @@
     x:Class="ClearDashboard.Wpf.Application.UserControls.AlignmentBulkReview"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    FontFamily="{StaticResource ClearDashboardFont}"
     xmlns:bulkAlignment="clr-namespace:ClearDashboard.Wpf.Application.UserControls.BulkAlignment"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:enhancedView1="clr-namespace:ClearDashboard.Wpf.Application.ViewModels.EnhancedView"
@@ -13,6 +12,7 @@
     d:DesignHeight="450"
     d:DesignWidth="800"
     helpers:Translation.ResourceManager="{x:Static resx:Resources.ResourceManager}"
+    FontFamily="{StaticResource ClearDashboardFont}"
     mc:Ignorable="d">
 
     <Grid VerticalAlignment="Top">

--- a/src/ClearDashboard.Wpf.Application/UserControls/BookSelector.xaml
+++ b/src/ClearDashboard.Wpf.Application/UserControls/BookSelector.xaml
@@ -2,7 +2,6 @@
     x:Class="ClearDashboard.Wpf.Application.UserControls.BookSelector"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:helpers="clr-namespace:ClearDashboard.Wpf.Application.Helpers;assembly=ClearDashboard.Wpf.Application.Abstractions"
     xmlns:local="clr-namespace:ClearDashboard.Wpf.Application.UserControls"

--- a/src/ClearDashboard.Wpf.Application/UserControls/BulkAlignment/AlignedWords.xaml
+++ b/src/ClearDashboard.Wpf.Application/UserControls/BulkAlignment/AlignedWords.xaml
@@ -3,7 +3,6 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:cm="http://caliburnmicro.com"
-    FontFamily="{StaticResource ClearDashboardFont}"
     xmlns:converters1="clr-namespace:ClearDashboard.Wpf.Application.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:enhancedView="clr-namespace:ClearDashboard.Wpf.Application.Views.EnhancedView"
@@ -14,6 +13,7 @@
     d:DesignHeight="450"
     d:DesignWidth="800"
     helpers:Translation.ResourceManager="{x:Static resx:Resources.ResourceManager}"
+    FontFamily="{StaticResource ClearDashboardFont}"
     mc:Ignorable="d">
     <UserControl.Resources>
         <converters1:BoolFlowDirectionConverter x:Key="BoolFlowDirectionConverter" />

--- a/src/ClearDashboard.Wpf.Application/UserControls/BulkAlignment/AlignmentApproval.xaml
+++ b/src/ClearDashboard.Wpf.Application/UserControls/BulkAlignment/AlignmentApproval.xaml
@@ -3,7 +3,6 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:cm="http://caliburnmicro.com"
-    FontFamily="{StaticResource ClearDashboardFont}"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:enhancedView="clr-namespace:ClearDashboard.Wpf.Application.Views.EnhancedView"
     xmlns:helpers="clr-namespace:ClearDashboard.Wpf.Application.Helpers;assembly=ClearDashboard.Wpf.Application.Abstractions"
@@ -15,6 +14,7 @@
     d:DesignHeight="450"
     d:DesignWidth="800"
     helpers:Translation.ResourceManager="{x:Static resx:Resources.ResourceManager}"
+    FontFamily="{StaticResource ClearDashboardFont}"
     mc:Ignorable="d">
     <UserControl.Resources>
         <Style TargetType="{x:Type Label}">

--- a/src/ClearDashboard.Wpf.Application/UserControls/BulkAlignment/AlignmentApprovalOptions.xaml
+++ b/src/ClearDashboard.Wpf.Application/UserControls/BulkAlignment/AlignmentApprovalOptions.xaml
@@ -4,7 +4,6 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:a="clr-namespace:ClearDashboard.Wpf.Application.Models.EnhancedView;assembly=ClearDashboard.Wpf.Application.Abstractions"
     xmlns:cm="http://caliburnmicro.com"
-    FontFamily="{StaticResource ClearDashboardFont}"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:helpers="clr-namespace:ClearDashboard.Wpf.Application.Helpers;assembly=ClearDashboard.Wpf.Application.Abstractions"
     xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
@@ -13,6 +12,7 @@
     d:DesignHeight="450"
     d:DesignWidth="800"
     helpers:Translation.ResourceManager="{x:Static resx:Resources.ResourceManager}"
+    FontFamily="{StaticResource ClearDashboardFont}"
     mc:Ignorable="d">
     <UserControl.Resources>
         <Style TargetType="{x:Type Label}">

--- a/src/ClearDashboard.Wpf.Application/UserControls/BulkAlignment/PivotAndAlignedWordOptions.xaml
+++ b/src/ClearDashboard.Wpf.Application/UserControls/BulkAlignment/PivotAndAlignedWordOptions.xaml
@@ -2,7 +2,6 @@
     x:Class="ClearDashboard.Wpf.Application.UserControls.BulkAlignment.PivotAndAlignedWordOptions"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    FontFamily="{StaticResource ClearDashboardFont}"
     xmlns:a="clr-namespace:ClearDashboard.Wpf.Application.Models.EnhancedView;assembly=ClearDashboard.Wpf.Application.Abstractions"
     xmlns:cm="http://caliburnmicro.com"
     xmlns:converters="clr-namespace:ClearDashboard.Wpf.Application.Converters;assembly=ClearDashboard.Wpf.Application.Abstractions"
@@ -15,6 +14,7 @@
     d:DesignHeight="450"
     d:DesignWidth="800"
     helpers:Translation.ResourceManager="{x:Static resx:Resources.ResourceManager}"
+    FontFamily="{StaticResource ClearDashboardFont}"
     mc:Ignorable="d">
     <UserControl.Resources>
         <converters:AlignmentTypesEnumToBooleanConverter x:Key="AlignmentTypesEnumToBooleanConverter" />

--- a/src/ClearDashboard.Wpf.Application/UserControls/BulkAlignment/PivotedWords.xaml
+++ b/src/ClearDashboard.Wpf.Application/UserControls/BulkAlignment/PivotedWords.xaml
@@ -3,7 +3,6 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:cm="http://caliburnmicro.com"
-    FontFamily="{StaticResource ClearDashboardFont}"
     xmlns:converters1="clr-namespace:ClearDashboard.Wpf.Application.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:enhancedView="clr-namespace:ClearDashboard.Wpf.Application.Views.EnhancedView"
@@ -14,6 +13,7 @@
     d:DesignHeight="450"
     d:DesignWidth="800"
     helpers:Translation.ResourceManager="{x:Static resx:Resources.ResourceManager}"
+    FontFamily="{StaticResource ClearDashboardFont}"
     mc:Ignorable="d">
     <UserControl.Resources>
         <converters1:BoolFlowDirectionConverter x:Key="BoolFlowDirectionConverter" />

--- a/src/ClearDashboard.Wpf.Application/Views/Startup/ProjectPickerView.xaml
+++ b/src/ClearDashboard.Wpf.Application/Views/Startup/ProjectPickerView.xaml
@@ -957,7 +957,19 @@
         </Grid>
 
         <!--  Errors  -->
-        <StackPanel Grid.Row="3" Grid.Column="0">
+        <StackPanel
+            Grid.Row="3"
+            Grid.Column="0"
+            Orientation="Horizontal">
+            <ProgressBar
+                Margin="10"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                IsIndeterminate="True"
+                Style="{StaticResource ClearDashboardCircularProgressBar}"
+                Visibility="{Binding ProjectLoadingProgressBarVisibility}"
+                Value="0" />
+
             <TextBlock
                 Width="500"
                 MaxWidth="340"


### PR DESCRIPTION
When users double-click on a project in the project picker and wait for it to load a message appears telling them the project is already open.  this is confusing so I added a loading wheel and prevented the "already open" message from showing if the loading wheel is visible.