### PR TITLE
Partial Verse Tokenization Issue

### DIFF
--- a/src/ClearDashboard.WebApiParatextPlugin/MainWindow.cs
+++ b/src/ClearDashboard.WebApiParatextPlugin/MainWindow.cs
@@ -1817,7 +1817,7 @@ namespace ClearDashboard.WebApiParatextPlugin
                                 String.CompareOrdinal(currentVersePart, previousVersePart) == 1)
                             {
                                 //then append verseText onto versetext of last element in verses
-                                verses.LastOrDefault().Text += verseText;
+                                verses.LastOrDefault().Text = verses.LastOrDefault().Text.TrimEnd() + " " + verseText;
                             }
                             else
                             {


### PR DESCRIPTION
From #1070 

Previously:
In a corpus, if a verse was broken up into parts a and b (ex. Mark 6:6a and Mark 6:6b) then we could not tokenize corpus.  We were unable to tokenize the corpus because we identified that there were duplicate token IDs for Mark 6:6 since there are two verses with the ID 041006006.  

Now:
When grabbing the text from paratext, if a verse marker looks like a partial verse then we check if the preceding verse was a partial verse.  If so then we check if the preceding verse had the same number and if their verse parts are subsequent.  If so then we append the text of the current verse marker onto the previous verse. 