### PR TITLE
Detect Consecutive Duplicate Verses

### DIFF
--- a/src/ClearDashboard.WebApiParatextPlugin/Helpers/ParatextExtractUSFM.cs
+++ b/src/ClearDashboard.WebApiParatextPlugin/Helpers/ParatextExtractUSFM.cs
@@ -219,18 +219,15 @@ namespace ClearDashboard.WebApiParatextPlugin.Helpers
                                                     // check if this has already been entered and is a duplicate
                                                     if (verseKey.ContainsKey(key))
                                                     {
-                                                        if (lastVerseRef != marker.VerseRef.ToString())
-                                                        {
-                                                            mainWindow.AppendText(Color.Red,
+                                                        mainWindow.AppendText(Color.Red,
                                                                 $"Duplicate verse {UsfmReferenceHelper.ConvertBbbcccvvvToReadable(key)}");
-                                                            usfmError.Add(new UsfmError
-                                                            {
-                                                                Reference = UsfmReferenceHelper
-                                                                    .ConvertBbbcccvvvToReadable(key),
-                                                                Error =
-                                                                    $"Duplicate verse {UsfmReferenceHelper.ConvertBbbcccvvvToReadable(key)}",
-                                                            });
-                                                        }
+                                                        usfmError.Add(new UsfmError
+                                                        {
+                                                            Reference = UsfmReferenceHelper
+                                                                .ConvertBbbcccvvvToReadable(key),
+                                                            Error =
+                                                                $"Duplicate verse {UsfmReferenceHelper.ConvertBbbcccvvvToReadable(key)}",
+                                                        });
                                                     }
                                                     else
                                                     {


### PR DESCRIPTION
Previously:
If the preceding verseID was the same as the current verseID then it wasn't being counted as a duplicate.

Test Case:
Proverbs 21:23 in the Syriac Peshitta (SYR)

P.S. 
I didn't realize that we don't use a function given to us by Paratext to check the USFM.