### PR TITLE
Delete the Old License

### DIFF
--- a/src/ClearDashboard.DAL/LicenseManager.cs
+++ b/src/ClearDashboard.DAL/LicenseManager.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using System.Threading.Tasks;
 
 namespace ClearDashboard.DataAccessLayer
 {
@@ -18,6 +19,24 @@ namespace ClearDashboard.DataAccessLayer
         public static string LicenseFolderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Microsoft", "UserSecrets", "License");
         public static string LicenseFileName = "license.txt";
         public static string LicenseFilePath = Path.Combine(LicenseFolderPath, LicenseFileName);
+
+        public static async Task<bool> DeleteOldLicense()
+        {
+            try
+            {
+                if (File.Exists(LicenseFilePath) && File.Exists(LegacyLicenseFilePath))
+                {
+                    File.Delete(LegacyLicenseFilePath);
+                    return true;
+                }
+            }
+            catch
+            {
+                return false;
+            }
+
+            return false;
+        }
 
         private static Aes CreateCryptoProvider()
         {

--- a/src/ClearDashboard.Wpf.Application/ViewModels/Startup/ProjectPickerViewModel.cs
+++ b/src/ClearDashboard.Wpf.Application/ViewModels/Startup/ProjectPickerViewModel.cs
@@ -525,6 +525,8 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Startup
                 
             await GetRemoteUser();
 
+            await LicenseManager.DeleteOldLicense();
+
             base.OnViewLoaded(view);
 
             _initializationComplete = true;


### PR DESCRIPTION
From #1071 

After checking whether or not the legacy license needs to be copied to the UserSecrets folder, we delete the legacy license if a license exists in the UserSecrets folder.