### PR TITLE
Aligned Token Highlighting and Drag Select

### DIFF
--- a/src/ClearDashboard.Wpf.Application/UserControls/TokenDisplay.xaml.cs
+++ b/src/ClearDashboard.Wpf.Application/UserControls/TokenDisplay.xaml.cs
@@ -1231,22 +1231,7 @@ namespace ClearDashboard.Wpf.Application.UserControls
 
         protected override async void OnIsKeyboardFocusWithinChanged(DependencyPropertyChangedEventArgs e)
         {
-
-            var tokenDisplay = (TokenDisplayViewModel)DataContext;
-
-            if (tokenDisplay.VerseDisplay is AlignmentDisplayViewModel)
-            {
-                if (e.NewValue != null && (bool)e.NewValue)
-                {
-                    var keyBoardModifiers = Keyboard.Modifiers;
-
-                    if (keyBoardModifiers == ModifierKeys.None || (Keyboard.IsKeyDown(Key.Tab) && keyBoardModifiers == ModifierKeys.Shift))
-                    {
-                        await EventAggregator.PublishOnUIThreadAsync(new HighlightTokensMessage(tokenDisplay.IsSource, tokenDisplay.AlignmentToken.TokenId), CancellationToken.None);
-                    }
-
-                }
-            }
+            HighlightAlignedToken();
             base.OnIsKeyboardFocusWithinChanged(e);
         }
 
@@ -1259,23 +1244,23 @@ namespace ClearDashboard.Wpf.Application.UserControls
         {
             RaiseTokenEvent(TokenLeftButtonDownEvent, e);
 
+            HighlightAlignedToken();
+            e.Handled = true;
+        }
+
+        private void HighlightAlignedToken()
+        {
             var tokenDisplay = (TokenDisplayViewModel)DataContext;
 
             if (tokenDisplay.VerseDisplay is AlignmentDisplayViewModel)
             {
-                //if (e.NewValue != null && (bool)e.NewValue)
-                //{
-                    var keyBoardModifiers = Keyboard.Modifiers;
+                var keyboardModifiers = Keyboard.Modifiers;
 
-                    if (keyBoardModifiers == ModifierKeys.None || (Keyboard.IsKeyDown(Key.Tab) && keyBoardModifiers == ModifierKeys.Shift))
-                    {
-                        EventAggregator.PublishOnUIThreadAsync(new HighlightTokensMessage(tokenDisplay.IsSource, tokenDisplay.AlignmentToken.TokenId), CancellationToken.None);
-                    }
-
-                //}
+                if (keyboardModifiers == ModifierKeys.None || (Keyboard.IsKeyDown(Key.Tab) && keyboardModifiers == ModifierKeys.Shift))
+                {
+                    EventAggregator.PublishOnUIThreadAsync(new HighlightTokensMessage(tokenDisplay.IsSource, tokenDisplay.AlignmentToken.TokenId), CancellationToken.None);
+                }
             }
-
-            e.Handled = true;
         }
 
         private void OnTokenLeftButtonUp(object sender, RoutedEventArgs e)


### PR DESCRIPTION
My intent isn't that this gets merged right away but that this is a way for you to help come up with the best solution.

I discovered that the [Fixing Drag Select PR](https://github.com/Clear-Bible/ClearDashboard/pull/1066) disabled aligned token highlighting (the teal/purple BorderBrush) 
![image](https://github.com/Clear-Bible/ClearDashboard/assets/60048070/e3b1655f-5550-46df-89e3-f1a72688be33)
![image](https://github.com/Clear-Bible/ClearDashboard/assets/60048070/1aa2be80-2437-4ebb-b79a-96a2dd3f2b14)
The problem is that because of using `e.Handled=true;` in `OnTokenLeftButtonDown` then `OnIsKeyboardFocusWithinChanged` doesn't run.  

Why do we need to use `e.Handled = true;` in the first place?  It's because we're using `MouseEnter` for Drag Select so [this problem](https://stackoverflow.com/questions/4681884/wpf-mouseenter-doesnt-work-on-several-buttons-when-mouse-is-pressed) arises.

One solution is to have the code inside `OnIsKeyboardFocusWithinChanged` run before the `e.Handled=true;` statement (as is demonstrated by the commit in this PR).  If you think this is a good idea then what needs to happen to make this PR production ready? (does the code need to be removed from `OnIsKeyboardFocusWithinChanged`? What do we do with `(e.NewValue != null && (bool)e.NewValue)`?)