### PR TITLE
Refreshing project list after importing collab changes

### DIFF
--- a/src/ClearDashboard.Wpf.Application/ViewModels/Startup/ProjectPickerViewModel.cs
+++ b/src/ClearDashboard.Wpf.Application/ViewModels/Startup/ProjectPickerViewModel.cs
@@ -975,6 +975,10 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Startup
                             {
                                 project.GitLabUpdateNeeded = true;
                             }
+                            else
+                            {
+                                project.GitLabUpdateNeeded = false;
+                            }
                         }
                     }
                 }
@@ -1489,6 +1493,8 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Startup
                     }
                 }
             }
+
+            await GetProjectsVersion();
         }
 
         #endregion  Methods


### PR DESCRIPTION
Something to consider: was there a reason that the `else` statement was excluded previously?  