### PR TITLE
Temp: removing sending seen functionality

### DIFF
--- a/src/ClearDashboard.Collaboration/Builder/NoteBuilder.cs
+++ b/src/ClearDashboard.Collaboration/Builder/NoteBuilder.cs
@@ -109,7 +109,8 @@ public class NoteBuilder : GeneralModelBuilder<Models.Note>
 
                 if (nusaDbModelsByNoteId.TryGetValue(reply.Id, out var rusas))
                 {
-                    modelSnapshot.AddChild<IModelSnapshot<Models.NoteUserSeenAssociation>>("NoteUserSeenAssociations", ExtractNoteUserSeenAssociations(rusas, builderContext));
+                    //TODO Chris, fix this, NoteUserSeenAssociations is being added to the snapshot multiple times and causing exceptions
+                    //modelSnapshot.AddChild<IModelSnapshot<Models.NoteUserSeenAssociation>>("NoteUserSeenAssociations", ExtractNoteUserSeenAssociations(rusas, builderContext));
                 }
 
                 replyModelSnapshots.Add(replyModelSnapshot);
@@ -120,7 +121,8 @@ public class NoteBuilder : GeneralModelBuilder<Models.Note>
 
         if (nusaDbModelsByNoteId.TryGetValue(note.Id, out var nusas))
         {
-            modelSnapshot.AddChild<IModelSnapshot<Models.NoteUserSeenAssociation>>("NoteUserSeenAssociations", ExtractNoteUserSeenAssociations(nusas, builderContext));
+            //TODO Chris, fix this, NoteUserSeenAssociations is being added to the snapshot multiple times and causing exceptions
+            //modelSnapshot.AddChild<IModelSnapshot<Models.NoteUserSeenAssociation>>("NoteUserSeenAssociations", ExtractNoteUserSeenAssociations(nusas, builderContext));
         }
 
         return modelSnapshot;


### PR DESCRIPTION
The NoteUserSeenAssociations field is being added to the snapshot multiple times when "seen" checkboxes are checked.  I didn't know how to fix it and neither did Dirk.  We are thinking we fix it with a hotfix later.