### PR TITLE
Stop Spamable Add Paratext Button

### DIFF
--- a/src/ClearDashboard.Wpf.Application.Abstractions/Controls/ProjectDesignSurface/DesignSurfaceViewModel.cs
+++ b/src/ClearDashboard.Wpf.Application.Abstractions/Controls/ProjectDesignSurface/DesignSurfaceViewModel.cs
@@ -43,7 +43,7 @@ namespace ClearDashboard.Wpf.Application.Controls.ProjectDesignSurface
     /// <summary>
     /// Defines a design surface with nodes and connections between the nodes.
     /// </summary>
-    public partial class DesignSurfaceViewModel : Screen, IHandle<BackgroundDeletionTaskRunning>
+    public partial class DesignSurfaceViewModel : Screen, IHandle<BackgroundDeletionTaskRunning>, IHandle<ProjectLoadedMessage>
     {
 
         public Guid Guid = Guid.NewGuid();
@@ -194,6 +194,14 @@ namespace ClearDashboard.Wpf.Application.Controls.ProjectDesignSurface
             get => _addManuscriptGreekEnabled;
             set => Set(ref _addManuscriptGreekEnabled, value);
         }
+
+        private bool _addParatextButtonEnabled = false;
+        public bool AddParatextButtonEnabled
+        {
+            get => _addParatextButtonEnabled;
+            set => Set(ref _addParatextButtonEnabled, value);
+        }
+
 
         /// <summary>
         /// This is the design surface that is displayed in the window.
@@ -1857,6 +1865,13 @@ namespace ClearDashboard.Wpf.Application.Controls.ProjectDesignSurface
                 // is not running to complete the connection
                 ConnectionDragCompleted(message.NewConnection, message.ConnectorDraggedOut, message.ConnectorDraggedOver);
             }
+
+            return Task.CompletedTask;
+        }
+
+        public Task HandleAsync(ProjectLoadedMessage message, CancellationToken cancellationToken)
+        {
+            AddParatextButtonEnabled = true;
 
             return Task.CompletedTask;
         }

--- a/src/ClearDashboard.Wpf.Application/ViewModels/Project/ProjectDesignSurfaceViewModel.cs
+++ b/src/ClearDashboard.Wpf.Application/ViewModels/Project/ProjectDesignSurfaceViewModel.cs
@@ -69,7 +69,6 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Project
         IHandle<UiLanguageChangedMessage>, 
         IHandle<RedrawParallelCorpusMenus>,
         IHandle<RedrawCorpusNodeMenus>, 
-        IHandle<ProjectLoadedMessage>, 
         IHandle<GetExternalNotesMessage>,
         IDisposable
     {
@@ -158,12 +157,12 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Project
             set => Set(ref _projectName, value);
         }
 
-        public bool _addParatextButtonEnabled = false;
-        public bool AddParatextButtonEnabled
-        {
-            get => _addParatextButtonEnabled;
-            set => Set(ref _addParatextButtonEnabled, value);
-        }
+        //public bool _addParatextButtonEnabled = false;
+        //public bool AddParatextButtonEnabled
+        //{
+        //    get => _addParatextButtonEnabled;
+        //    set => Set(ref _addParatextButtonEnabled, value);
+        //}
 
         private Visibility _pdsVisibility = Visibility.Collapsed;
         public Visibility PdsVisibility
@@ -278,7 +277,7 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Project
 
             if(ProjectManager.IsParatextConnected)
             {
-                AddParatextButtonEnabled = true;
+                DesignSurfaceViewModel.AddParatextButtonEnabled = true;
             }
 
         }
@@ -869,12 +868,6 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Project
 
         public async Task AddParatextCorpus()
         {
-            if (_busyState.Keys.Any(k => k.StartsWith("AddParatextCorpus_")))
-            {
-                // prevent spamming of the Add Paratext Corpus button
-                return;
-            }
-
             await AddParatextCorpus("");
         }
 
@@ -897,6 +890,8 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Project
 
                 if (result)
                 {
+                    DesignSurfaceViewModel!.AddParatextButtonEnabled = false;
+
                     // check to see if we want to run this in High Performance mode
                     if (Settings.Default.EnablePowerModes && _systemPowerModes.IsLaptop)
                     {
@@ -908,7 +903,7 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Project
 
                     var selectedProject = dialogViewModel!.SelectedProject;
                     var bookIds = dialogViewModel.BookIds;
-                    var taskName = $"AddParatextCorpus_{selectedProject!.Name}";
+                    var taskName = $"{selectedProject!.Name}";
                     _busyState.Add(taskName, true);
 
                     var task = _longRunningTaskManager!.Create(taskName, LongRunningTaskStatus.Running);
@@ -1052,8 +1047,9 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Project
                         }
                         finally
                         {
+                            DesignSurfaceViewModel!.AddParatextButtonEnabled = true;
                             _longRunningTaskManager.TaskComplete(taskName);
-                            _busyState.Remove($"AddParatextCorpus_{selectedProject!.Name}");
+                            _busyState.Remove($"{selectedProject!.Name}");
                             if (cancellationToken.IsCancellationRequested)
                             {
                                 DeleteCorpusNode(node, true);
@@ -2337,12 +2333,7 @@ namespace ClearDashboard.Wpf.Application.ViewModels.Project
             }
         }
 
-        public Task HandleAsync(ProjectLoadedMessage message, CancellationToken cancellationToken)
-        {
-            AddParatextButtonEnabled = true;
 
-            return Task.CompletedTask;
-        }
 
         #endregion
 

--- a/src/ClearDashboard.Wpf.Application/Views/Project/ProjectDesignSurfaceView.xaml
+++ b/src/ClearDashboard.Wpf.Application/Views/Project/ProjectDesignSurfaceView.xaml
@@ -512,7 +512,7 @@
                         Margin="10,0,10,10"
                         cm:Message.Attach="AddParatextCorpus()"
                         Content="{helpers:Localization ProjectPicker_Paratext}"
-                        IsEnabled="{Binding AddParatextButtonEnabled}"
+                        IsEnabled="{Binding DesignSurfaceViewModel.AddParatextButtonEnabled}"
                         Style="{StaticResource BigParatextButton}"
                         Tag=" ScriptTextOutline" />
 


### PR DESCRIPTION
see #1195 

So this prevents duplicate Paratext hits.  I tried to have it so that only ONE new Add Paratext dialog would open at at a time but since the dialog gets locked, there isn't a new project to add in to the busy state yet.  This solution works by preventing any new windows opening when another Paratext corpus is being added.