### PR TITLE
Deleting a Jot

### DIFF
--- a/src/ClearDashboard.Wpf.Application/UserControls/Notes/LabelsEditor.xaml.cs
+++ b/src/ClearDashboard.Wpf.Application/UserControls/Notes/LabelsEditor.xaml.cs
@@ -445,7 +445,10 @@ namespace ClearDashboard.Wpf.Application.UserControls.Notes
         private void OnLabelGroupSelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             RaiseLabelGroupEvent(LabelGroupSelectedEvent, CurrentLabelGroup);
-            CurrentLabelGroup ??= LabelGroups.FirstOrDefault();
+            if (LabelGroups != null)
+            {
+                CurrentLabelGroup ??= LabelGroups.FirstOrDefault();
+            }
             if (CurrentLabelGroup != null)
             {
                 LabelSuggestions = CurrentLabelGroup.Labels;


### PR DESCRIPTION
from #1245 

When removing a Note from Notes in NoteCollectionDisplay.xaml.cs an error was triggered
![image](https://github.com/Clear-Bible/ClearDashboard/assets/60048070/9eb89e2e-d783-46f0-bac0-ab29e709af87)

The issue was that the LabelGroups property in LabelsEditor.xaml.cs was sometimes null.  I don't know why it was null.
![image](https://github.com/Clear-Bible/ClearDashboard/assets/60048070/aaffaa6e-141b-4704-9a3a-080315f3a2a6)
