### PR TITLE
Jot Doesn't Archive when External Notes is Turned on

### DIFF
--- a/src/ClearDashboard.Wpf.Application/ViewModels/Notes/JotsEditorViewModel.cs
+++ b/src/ClearDashboard.Wpf.Application/ViewModels/Notes/JotsEditorViewModel.cs
@@ -268,10 +268,10 @@ public class JotsEditorViewModel : ApplicationScreen
         }
     }
 
-    public void NoteSendToParatext(object sender, NoteEventArgs e)
+    public async void NoteSendToParatext(object sender, NoteEventArgs e)
     {
-        Task.Run(() => NoteSendToParatextAsync(e).GetAwaiter());
-        EventAggregator.PublishOnUIThreadAsync(new ReloadExternalNotesDataMessage(ReloadType.Refresh), CancellationToken.None);
+        await NoteSendToParatextAsync(e);
+        await EventAggregator.PublishOnUIThreadAsync(new ReloadExternalNotesDataMessage(ReloadType.Refresh), CancellationToken.None);
     }
     
     public async Task NoteSendToParatextAsync(NoteEventArgs e)

--- a/src/ClearDashboard.Wpf.Application/ViewModels/Notes/JotsPanelViewModel.cs
+++ b/src/ClearDashboard.Wpf.Application/ViewModels/Notes/JotsPanelViewModel.cs
@@ -802,17 +802,17 @@ public JotsPanelViewModel()
             ConfirmationText = LocalizationService!["Notes_SendConfirmation"];
         }
 
-        private void SendNotesToParatext()
+        private async void SendNotesToParatext()
         {
             foreach (NoteViewModel note in NotesCollectionView)
             {
                 if (note.IsSelectedForBulkAction && note.EnableParatextSend)
                 {
-                    Task.Run(() => SendNotesToParatextAsync(note).GetAwaiter());
+                    await SendNotesToParatextAsync(note);
                 }
             }
 
-            EventAggregator.PublishOnUIThreadAsync(new ReloadExternalNotesDataMessage(ReloadType.Refresh),CancellationToken.None);
+            await EventAggregator.PublishOnUIThreadAsync(new ReloadExternalNotesDataMessage(ReloadType.Refresh),CancellationToken.None);
         }
 
         public async Task SendNotesToParatextAsync(NoteViewModel note)


### PR DESCRIPTION
# MERGE HOTFIX FIRST

I'm not sure if you want this merged into `DEV` or `net8` since this ticket isn't scheduled for the Hot Fix.  This branch is based on `net8` but the changes are small enough that I can just redo it if we want to merge directly into `DEV`.

From #1275 

The reason it wouldn't archive is that the SendToParatext methods were being run asynchronously at the same time as the External Notes refresh process (which is an async blocking process).  So when the SendToParatext methods tried to write the archived NoteStatus to the database it wasn't able to because the database was locked due to the External Notes Refresh process.  

The solution was to await the SendNoteToParatext methods.  Just eyeballing it, the performance impact seems to be that it takes about a half-a-second longer for the external notes flag to show up. 
