### PR TITLE
#1282 continued

### DIFF
--- a/src/ClearDashboard.Wpf.Application.Abstractions/Services/NoteManager.cs
+++ b/src/ClearDashboard.Wpf.Application.Abstractions/Services/NoteManager.cs
@@ -492,7 +492,10 @@ namespace ClearDashboard.Wpf.Application.Services
 
                 noteViewModel.Associations = GetNoteAssociations(associatedEntityIds, domainEntityContexts);
 
-                noteViewModel.Replies = new NoteViewModelCollection((await note.GetReplyNotes(Mediator)).Select(n => new NoteViewModel(n)));
+                if (!note.IsReply())
+                {
+                    noteViewModel.Replies = new NoteViewModelCollection((await note.GetReplyNotes(Mediator)).Select(n => new NoteViewModel(n)));
+                }
 
                 if (doGetParatextSendNoteInformation)
                 {
@@ -505,7 +508,7 @@ namespace ClearDashboard.Wpf.Application.Services
                 }
                 stopwatch.Stop();
                 Logger?.LogInformation($"Retrieved details for note \"{note.Text}\" ({noteId.Id}) in {stopwatch.ElapsedMilliseconds}ms");
-
+                
                 NotesCache[noteId.Id] = noteViewModel;
 
                 return noteViewModel;

--- a/src/ClearDashboard.Wpf.Application/ViewModels/Notes/JotsPanelViewModel.cs
+++ b/src/ClearDashboard.Wpf.Application/ViewModels/Notes/JotsPanelViewModel.cs
@@ -537,7 +537,10 @@ public JotsPanelViewModel()
 
                             foreach (var note in list)
                             {
-                                NoteViewModels.Add(note);
+                                if (!note.Entity.IsReply())
+                                {
+                                    NoteViewModels.Add(note);
+                                }
                             }
 
                             //noteVms


### PR DESCRIPTION
From [#1282](https://github.com/Clear-Bible/ClearDashboard/issues/1282#issuecomment-2075452334)

When a user made a reply on a Jot and then restarted the application the Jots lower panel failed to load.  This is related to 1282 because I think it came about due to changing how replies relate to DomainEntityIds.

The problem was that `GetReplyNotes` `throws` if it is asked to get the replies for a reply.  

My solution was to not call `GetReplyNotes` if the note in question is a reply.  Since this change was made I also needed to exclude replies from appearing the lower panel (previously they were being excluded because of the `throw`).