### PR TITLE
Fixing Drag Select

### DIFF
--- a/src/ClearDashboard.Wpf.Application/ApplicationModule.cs
+++ b/src/ClearDashboard.Wpf.Application/ApplicationModule.cs
@@ -65,10 +65,10 @@ namespace ClearDashboard.Wpf.Application
             builder.RegisterType<NoteManager>().AsSelf().SingleInstance();
             builder.RegisterType<NoteManager>().AsSelf().Keyed<NoteManager>("JotsNoteManager").InstancePerDependency();
 
+            // This is the transient instance used by the registration below to get a cloned version of the SelectionManager 
+            builder.RegisterType<SelectionManager>().AsSelf().Keyed<SelectionManager>("TransientSelectionManager").InstancePerDependency();
             // This is the singleton instance used by the EnhancedViews
             builder.RegisterType<SelectionManager>().AsSelf().SingleInstance();
-            // This is the transient instance used by the registration below to get a cloned version of the SelectionManager 
-            builder.RegisterType<SelectionManager>().AsSelf().Keyed<SelectionManager>("TransientSelectionManager").InstancePerDependency(); ;
 
             // This is the transient instance used by the JotsEditor
             //builder.Register<SelectionManager>(c =>


### PR DESCRIPTION
# MERGE IN HOTFIX FIRST

From #1289 

Drag-select didn't work because there were multiple SelectionManagers being used.  This was because we added the following line to the ApplicationModule so that we clone a SelectionManager and send it to the JotsPanel so that it would get some relevant information.  

![image](https://github.com/Clear-Bible/ClearDashboard/assets/60048070/e7f1e993-8535-459d-8ccf-1b2a699423cd)

Swapping the place of the two SelectionManager statements in the ApplicationModule solved the issue.  The Singleton now gets used by default rather than the transient.  

![image](https://github.com/Clear-Bible/ClearDashboard/assets/60048070/875d02f0-853a-46d7-873b-90aef2d1d139)
