### PR TITLE
disposing of VerseDisplayViewModels

### DIFF
--- a/src/ClearDashboard.Wpf.Application.Abstractions/ViewModels/EnhancedView/VerseAwareEnhancedViewItemViewModel.cs
+++ b/src/ClearDashboard.Wpf.Application.Abstractions/ViewModels/EnhancedView/VerseAwareEnhancedViewItemViewModel.cs
@@ -286,6 +286,13 @@ namespace ClearDashboard.Wpf.Application.ViewModels.EnhancedView
             {
                 _ = await Task.Factory.StartNew(async () =>
                     {
+                        foreach (var viewModel in Verses)
+                        {
+                            if (viewModel is IDisposable disposable)
+                            {
+                                disposable.Dispose();
+                            }
+                        }
                         Verses.Clear();
 
                         FetchingData = true;

--- a/src/ClearDashboard.Wpf.Application.Abstractions/ViewModels/EnhancedView/VerseDisplayViewModel.cs
+++ b/src/ClearDashboard.Wpf.Application.Abstractions/ViewModels/EnhancedView/VerseDisplayViewModel.cs
@@ -48,7 +48,7 @@ namespace ClearDashboard.Wpf.Application.ViewModels.EnhancedView
         IHandle<NoteMouseLeaveMessage>,
         IHandle<TokensJoinedMessage>,
         IHandle<TokenUnjoinedMessage>,
-        IHandle<TokenSplitMessage>
+        IHandle<TokenSplitMessage>, IDisposable
     {
 
         #region Member Variables   
@@ -141,6 +141,8 @@ namespace ClearDashboard.Wpf.Application.ViewModels.EnhancedView
         }
 
         private bool _multipleExternalNotes = false;
+        private bool disposedValue;
+
         public bool MultipleExternalNotes
         {
             get => _multipleExternalNotes && AbstractionsSettingsHelper.GetShowExternalNotes() && AbstractionsSettingsHelper.GetExternalNotesEnabled();
@@ -730,6 +732,11 @@ namespace ClearDashboard.Wpf.Application.ViewModels.EnhancedView
             }
 
             public int GetHashCode([DisallowNull] TokenId obj) => obj.BookNumber ^ obj.ChapterNumber ^ obj.VerseNumber;
+        }
+
+        public void Dispose()
+        {
+            EventAggregator.Unsubscribe(this);
         }
     }
 }


### PR DESCRIPTION
From #1227 

We need to unsubscribe from the event aggregator in order to remove these items from memory when we clear the `Verses` collection in VerseAwareEnhancedViewItemViewModel.

I didn't check if other viewmodels are persisting in memory.  Do you want me to do that?