### PR TITLE
updating selection based on all verses rather that just one

### DIFF
--- a/src/ClearDashboard.Wpf.Application/ViewModels/EnhancedView/EnhancedViewModel.cs
+++ b/src/ClearDashboard.Wpf.Application/ViewModels/EnhancedView/EnhancedViewModel.cs
@@ -1030,7 +1030,10 @@ namespace ClearDashboard.Wpf.Application.ViewModels.EnhancedView
         {
             if (SelectionManager.IsDragInProcess)
             {
-                SelectionManager.UpdateSelection(e.TokenDisplay, e.SelectedTokens, e.IsControlPressed);
+                TokenDisplayViewModelCollection selectedTokensAcrossAllVersesCollection = new(); 
+                selectedTokensAcrossAllVersesCollection.AddRangeDistinct(SelectionManager.SelectedTokens);
+                selectedTokensAcrossAllVersesCollection.AddRangeDistinct(e.SelectedTokens);
+                SelectionManager.UpdateSelection(e.TokenDisplay, selectedTokensAcrossAllVersesCollection, e.IsControlPressed);
             }
 
             Message = $"'{e.TokenDisplay.SurfaceText}' token ({e.TokenDisplay.Token.TokenId}) hovered";


### PR DESCRIPTION
## The Presenting Problem:
Users are not able to make jots across multiple verses.  When they hover over a token in another verse their selection resets.

## The Technical Problem:
When the mouse enters a token it updates the selected tokens to be all the tokens that are in e.SelectedTokens for that verse.  This means that when the mouse enters a token in a verse with nothing selected then all tokens (even the tokens in other verses) are deselected.

## Solution:
Update the token selection not just with all the tokens selected in that verse but with all the tokens selected in all verses.
