### PR TITLE
Disabling "Train" button when SMT is running

### DIFF
--- a/src/ClearDashboard.Wpf.Application/Views/Project/ParallelCorpusDialog/SmtModelStepView.xaml
+++ b/src/ClearDashboard.Wpf.Application/Views/Project/ParallelCorpusDialog/SmtModelStepView.xaml
@@ -85,24 +85,9 @@
             <Button
                 x:Name="Train"
                 Content="{helpers:Localization ParallelCorpusDialog_Train}"
-                IsDefault="True">
-                <Button.Style>
-                    <Style BasedOn="{StaticResource TransparentStyleButtonNoIsEnabledTrigger}" TargetType="Button">
-                        <Setter Property="IsEnabled" Value="False" />
-                        <Style.Triggers>
-                            <MultiDataTrigger>
-                                <MultiDataTrigger.Conditions>
-                                    <Condition Binding="{Binding SMTsReady}" Value="True" />
-                                    <Condition Binding="{Binding ParentViewModel.IsBusy, Converter={StaticResource BooleanInversionConverter}}" Value="True" />
-                                </MultiDataTrigger.Conditions>
-                                <MultiDataTrigger.Setters>
-                                    <Setter Property="IsEnabled" Value="True" />
-                                </MultiDataTrigger.Setters>
-                            </MultiDataTrigger>
-                        </Style.Triggers>
-                    </Style>
-                </Button.Style>
-            </Button>
+                IsDefault="True"
+                IsEnabled="{Binding ParentViewModel.IsBusy, Converter={StaticResource BooleanInversionConverter}}"
+                Style="{StaticResource TransparentStyle}" />
             <!--<TextBlock Text="{Binding SMTsReady}" />
             <TextBlock Text="{Binding ParentViewModel.IsBusy, Converter={StaticResource BooleanInversionConverter}}" />-->
         </StackPanel>


### PR DESCRIPTION
From #1322 

I didn't add in the "Wait" text like he asked for since we don't do that anywhere else.

The reason it wasn't originally like this is kind of explained in [the original PR](https://github.com/Clear-Bible/ClearDashboard/pull/870).  Basically, it sounds like at that point we didn't have the dropdown in the dialog preselect an SMT.

