### PR TITLE
Removing the EnhancedView that's added by as a placeholder

### DIFF
--- a/src/ClearDashboard.Wpf.Application.Abstractions/ViewModels/EnhancedView/Messages/CloseDockingPane.cs
+++ b/src/ClearDashboard.Wpf.Application.Abstractions/ViewModels/EnhancedView/Messages/CloseDockingPane.cs
@@ -2,4 +2,4 @@
 
 namespace ClearDashboard.Wpf.Application.ViewModels.EnhancedView.Messages;
 
-public record CloseDockingPane(Guid Guid);
+public record CloseDockingPane(Guid Guid, bool showConfirmation = true);

--- a/src/ClearDashboard.Wpf.Application/ViewModels/EnhancedView/EnhancedViewModel.cs
+++ b/src/ClearDashboard.Wpf.Application/ViewModels/EnhancedView/EnhancedViewModel.cs
@@ -380,6 +380,13 @@ namespace ClearDashboard.Wpf.Application.ViewModels.EnhancedView
         {
             await EventAggregator.PublishOnUIThreadAsync(new CloseDockingPane(this.PaneId));
         }
+
+        //I'm doing a separate method because when I modify the signature of "RequestClose" then
+        //"RequestCloseCommand = new RelayCommandAsync(RequestClose);" complains
+        public async Task RequestClose(object? obj, bool showConfirmation = true) 
+        {
+            await EventAggregator.PublishOnUIThreadAsync(new CloseDockingPane(this.PaneId, showConfirmation));
+        }
         #endregion
 
         #region Constructor


### PR DESCRIPTION
from #1224 

This is kind of a hacky solution.

### Previously
We add an EnhancedView to the MainView as a placeholder in `ActivateDockedWindowViewModels` in `MainViewModel`.
Then when we `LoadEnhancedViewTabs` we try to modify the placeholder to have the same details as our first saved EnhancedView.

### The Problem
When we try to change the details of the placeholder EnhancedView nothing visually changes.

### Proposed Fix
Rather than overwriting the placeholder EnhancedView, we create all of our saved EnhancedViews separately and then remove the placeholder.
