### PR TITLE
Removing ReloadDataMessage for JoinTokensAsync

### DIFF
--- a/src/ClearDashboard.Wpf.Application.Abstractions/Services/VerseManager.cs
+++ b/src/ClearDashboard.Wpf.Application.Abstractions/Services/VerseManager.cs
@@ -50,7 +50,6 @@ namespace ClearDashboard.Wpf.Application.Services
 
                 await EventAggregator.PublishOnUIThreadAsync(new TokensJoinedMessage(compositeToken, tokens, parallelCorpusId!));
                 SelectionManager.SelectionUpdated();
-                await EventAggregator.PublishOnUIThreadAsync(new ReloadDataMessage(ReloadType.Force));
             }
             catch (Exception e)
             {


### PR DESCRIPTION
TL;DR I've reverting the UI refresh code for Join-Tokens back to how it was in 1.4

### The reasons for removing `ReloadDataMessage`:  If this line is included then...
1. Sometimes when joining tokens in the VerseView, if there is also an Interlinear or AlignmentView in the MainView then the ParallelCorpus will become corrupted and unusable, resulting in data loss.
![image](https://github.com/user-attachments/assets/31174544-cfe4-4b21-971f-7ffbca6c7aa3)
2. This line of code does not guarantee that the UI will properly refresh after joining/unjoining tokens.  I have seen it fail to do so.  
3. This line is not necessary for the UI to properly refresh after joining/unjoining tokens.  Often (but not always) the UI properly refreshes for me when `ReloadDataMessage` is not included.

### Even without `ReloadDataMessage` there are several issues remaining:
1. Often (but not always) when joining tokens for the first time on a verse in the VerseView, a denormalization error will occur.
![image](https://github.com/user-attachments/assets/0b1a3063-337b-44c6-8426-0c15b3dd2bd2)  
2. Sometimes the UI does not refresh properly when joining/unjoining tokens.
3. Sometimes when joining tokens a message reading "This Visual is not connected to a PresentationSource" appears.  This message appears even when `ReloadDataMessage` is not included.  
![image](https://github.com/user-attachments/assets/b372afe2-249c-492b-a5c0-38a4149a1fe6)

### Why are these issues happening?  My theory...
Due to these issue's inconsistency, I think there is some kind of race condition, possibly involving the denormalization background task.  The problems became more prevalent when `ReloadDataMessage` was placed directly after `await TokenizedTextCorpus.PutCompositeToken(Mediator, compositeToken, parallelCorpusId);` rather than at the very end of `JoinTokensAsync`.  I wonder if the issue is that while the denormalization is being saved to the database another method is trying to access the database (as might be indicated by the denormalization error message below). 

![image](https://github.com/user-attachments/assets/e2e204d4-01f3-4aff-b67c-10eae13f0409)
