### PR TITLE
Fix for Grammar autocomplete search

### DIFF
--- a/src/ClearDashboard.Wpf.Application/ViewModels/EnhancedView/SplitTokenDialogViewModel.cs
+++ b/src/ClearDashboard.Wpf.Application/ViewModels/EnhancedView/SplitTokenDialogViewModel.cs
@@ -28,14 +28,32 @@ using Translation = ClearDashboard.DAL.Alignment.Translation.Translation;
 using ClearDashboard.Wpf.Application.ViewModels.EnhancedView.Lexicon;
 using ClearDashboard.Wpf.Application.ViewModels.EnhancedView.Messages;
 using ClearDashboard.Wpf.Application.Messages;
+using DotNetKit.Windows.Controls;
 
 // ReSharper disable UnusedMember.Global
 
 namespace ClearDashboard.Wpf.Application.ViewModels.EnhancedView
 {
+
+    public class CustomAutoCompleteSetting : AutoCompleteComboBoxSetting
+    {
+        public CustomAutoCompleteSetting()
+        {
+            
+        }
+
+        public override Predicate<object> GetFilter(string query, Func<object, string> stringFromItem)
+        {
+            query = query.Trim('[');
+            return item => stringFromItem(item).IndexOf(query, StringComparison.InvariantCultureIgnoreCase) >= 0;
+        }
+    }
+
     public class SplitTokenDialogViewModel : DashboardApplicationScreen
     {
         public VerseManager? VerseManager { get; }
+
+        public CustomAutoCompleteSetting AutoCompleteSetting { get; } = new CustomAutoCompleteSetting();
 
 
         public BindableCollection<SplitInstructionViewModel> SplitInstructionsViewModels { get; private set; } = new();

--- a/src/ClearDashboard.Wpf.Application/Views/EnhancedView/SplitTokenDIalogView.xaml
+++ b/src/ClearDashboard.Wpf.Application/Views/EnhancedView/SplitTokenDIalogView.xaml
@@ -22,6 +22,8 @@
         <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
         <converters:BoolToVisibilityCollapsedConverter x:Key="BoolToVisibilityCollapsedConverter" />
 
+        <viewModels:CustomAutoCompleteSetting x:Key="AutoCompleteSetting" />
+
         <Style x:Key="ListViewTextBlockStyle" TargetType="TextBlock">
             <Setter Property="FontFamily" Value="{DynamicResource MaterialDesignFont}" />
             <Setter Property="FontSize" Value="16" />
@@ -146,7 +148,8 @@
                                     ItemsSource="{Binding ElementName='SplitTokenListView', Path='DataContext.GrammarSuggestions' }"
                                     SelectedItem="{Binding Grammar, Mode=OneWayToSource}"
                                     Style="{StaticResource MaterialDesignComboBox}"
-                                    TextSearch.TextPath="ShortName">
+                                    Setting="{Binding ElementName='SplitTokenListView', Path='DataContext.AutoCompleteSetting'}" 
+                                    TextSearch.TextPath="Description">
                                         <controls:AutoCompleteComboBox.ItemTemplate>
                                             <DataTemplate>
                                                 <StackPanel Orientation="Vertical">


### PR DESCRIPTION
This addresses the issue Bethany reported related to searching for the terms "verb" and "noun" in the split token dialog.